### PR TITLE
Push Pull of Panelloads and Lineloads

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -30,6 +30,9 @@ using BH.Engine.Structure;
 using BH.oM.Structure.Loads;
 using BH.oM.Base;
 using System.Security.Policy;
+using BH.oM.Adapters.RFEM6.BHoMDataStructure.SupportDatastrures;
+using BH.oM.Adapters.RFEM6.Fragments.Enums;
+using BH.Engine.Spatial;
 
 namespace RFEM_Toolkit_Test.Loading
 {
@@ -261,27 +264,30 @@ namespace RFEM_Toolkit_Test.Loading
             Point p0 = new Point() { X = 0, Y = -1000, Z = 0 };
             Point p1 = new Point() { X = 0, Y = 10, Z = 0 };
 
-            Point p3 = new Point() { X = 1, Y = -2, Z = 0 };
-            Point p4 = new Point() { X = 1, Y = 2, Z = 0 };
+            Point p3 = panel0.ExternalEdges.First().Curve.ControlPoints().First();
+            Point p4 = panel0.ExternalEdges.First().Curve.ControlPoints().Last();
 
+            GeometricalLineLoad freeGeometricalLineLoad = new GeometricalLineLoad() { Name = "name1", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
+            //GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "name2", Location = BH.Engine.Geometry.Create.Line(p3, p4), MomentA = BH.Engine.Geometry.Create.Vector(0, 0, 0), MomentB = BH.Engine.Geometry.Create.Vector(0, 0, 1000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
+            GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "name2", Location = BH.Engine.Geometry.Create.Line(p3, p4), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 0), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 1000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
-            GeometricalLineLoad freeGeometricalLineLoad = new GeometricalLineLoad() { Name = "Free", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+            freeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.AddFragment(freeGeometricalLineLoad, new RFEM6GeometricalLineLoadTypes() { geometrialLineLoadType = GeometricalLineLoadTypesEnum.FreeLineLoad }, false);
 
-            GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "NonFree", Location = BH.Engine.Geometry.Create.Line(p3, p4), MomentA = BH.Engine.Geometry.Create.Vector(0, 0, 0), MomentB = BH.Engine.Geometry.Create.Vector(0, 0, 1000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+            //nonFreeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.AddFragment(nonFreeGeometricalLineLoad, new RFEM6GeometricalLineLoadTypes() {geometrialLineLoadType=GeometricalLineLoadTypesEnum.NonFreeLineLoad }, false);
 
             //freeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.SetPropertyValue(freeGeometricalLineLoad, "Panels"/*, new List<Panel>() { panel0, panel1 }*/);
 
 
             //((List<BH.oM.Structure.Elements.Panel>)geometricalLineLoad.CustomData.ToList()[0].Value).Count();
 
-            //adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
-            //adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
+            adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
+            adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
 
-            FilterRequest linload = new FilterRequest() { Type = typeof(GeometricalLineLoad) };
-            var lineloads = adapter.Pull(linload).ToList();
-            var lineload0 = (GeometricalLineLoad)lineloads[0];
+            //FilterRequest linload = new FilterRequest() { Type = typeof(GeometricalLineLoad) };
+            //var lineloads = adapter.Pull(linload).ToList();
+            //var lineload0 = (GeometricalLineLoad)lineloads[0];
 
 
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -237,6 +237,15 @@ namespace RFEM_Toolkit_Test.Loading
             var l0 = (GeometricalLineLoad)loads[0];
 
         }
+        
+        [Test]
+        public void PullBarload()
+        {
+            FilterRequest loadFilter = new FilterRequest() { Type = typeof(BarUniformlyDistributedLoad) };
+            var loads = adapter.Pull(loadFilter).ToList();
+            var l0 = (BarUniformlyDistributedLoad)loads[0];
+
+        }
 
         //[Test]
         //public void PushLineLoad()
@@ -324,6 +333,31 @@ namespace RFEM_Toolkit_Test.Loading
 
         //}
 
+        [Test]
+        public void PushPullBarLoad()
+        {
+            n1 = new Node() { Position = new Point() { X = 0, Y = 10, Z = 0 }, Support = BH.Engine.Structure.Create.FixConstraint6DOF() };
+            n2 = new Node() { Position = new Point() { X = 10, Y = 10, Z = 0 }, Support = BH.Engine.Structure.Create.FixConstraint6DOF() };
 
+            ISectionProperty section1 = BH.Engine.Library.Query.Match("EU_SteelSections", "IPE 300", true, true) as ISectionProperty;
+
+            bar = new Bar() { StartNode = n1, EndNode = n2, SectionProperty = section1 };
+
+
+            //LoadCases
+            Loadcase loadcaseDL = new Loadcase() { Name = "DeadLoad", Nature = LoadNature.Dead, Number = 1 };
+
+            var barGroup = new BH.oM.Base.BHoMGroup<Bar>() { Elements = new List<Bar> { bar } };
+            var barLoad0 = new BH.oM.Structure.Loads.BarUniformlyDistributedLoad() { Objects = barGroup, Loadcase = loadcaseDL, Force = new Vector() { X = 1000, Y = 0, Z = 0 } };
+
+            HashSet<ILoad> barloads = new HashSet<ILoad>() { barLoad0 };
+
+            adapter.Push(barloads.ToList());
+
+
+
+
+
+        }
     }
 }

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -264,10 +264,10 @@ namespace RFEM_Toolkit_Test.Loading
 
             GeometricalLineLoad geometricalLineLoad = new GeometricalLineLoad() { Name = "Free", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
-            geometricalLineLoad= (GeometricalLineLoad) BH.Engine.Base.Modify.SetPropertyValue(geometricalLineLoad, "Panels", new List<Panel>() { panel0 });
+            geometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.SetPropertyValue(geometricalLineLoad, "Panels", new List<Panel>() { panel0 });
 
 
-            ((List<BH.oM.Structure.Elements.Panel>)geometricalLineLoad.CustomData.ToList()[0].Value).Count();
+            //((List<BH.oM.Structure.Elements.Panel>)geometricalLineLoad.CustomData.ToList()[0].Value).Count();
 
             adapter.Push(new List<IObject>() { geometricalLineLoad });
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -247,6 +247,32 @@ namespace RFEM_Toolkit_Test.Loading
 
         }
 
+        [Test]
+        public void PushFreeLineLoadload()
+        {
+            FilterRequest loadFilter = new FilterRequest() { Type = typeof(Panel) };
+            var panels = adapter.Pull(loadFilter).ToList();
+            var panel0 = (Panel)panels[0];
+
+            
+
+            Point p0 = new Point() { X = 0, Y = -10, Z = 0 };
+            Point p1 = new Point() { X = 0, Y = 10, Z = 0 };
+
+
+
+
+            GeometricalLineLoad geometricalLineLoad = new GeometricalLineLoad() { Name = "Free", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+
+            geometricalLineLoad= (GeometricalLineLoad) BH.Engine.Base.Modify.SetPropertyValue(geometricalLineLoad, "Panels", new List<Panel>() { panel0 });
+
+
+            ((List<BH.oM.Structure.Elements.Panel>)geometricalLineLoad.CustomData.ToList()[0].Value).Count();
+
+            adapter.Push(new List<IObject>() { geometricalLineLoad });
+
+        }
+
         //[Test]
         //public void PushLineLoad()
         //{
@@ -353,7 +379,7 @@ namespace RFEM_Toolkit_Test.Loading
             HashSet<ILoad> barloads = new HashSet<ILoad>() { barLoad0 };
 
             adapter.Push(barloads.ToList());
-
+            adapter.Push(barloads.ToList());
 
 
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -253,7 +253,7 @@ namespace RFEM_Toolkit_Test.Loading
             FilterRequest loadFilter = new FilterRequest() { Type = typeof(Panel) };
             var panels = adapter.Pull(loadFilter).ToList();
             var panel0 = (Panel)panels[0];
-            var panel1 = (Panel)panels[1];
+            //var panel1 = (Panel)panels[1];
 
 
 
@@ -277,7 +277,7 @@ namespace RFEM_Toolkit_Test.Loading
             //((List<BH.oM.Structure.Elements.Panel>)geometricalLineLoad.CustomData.ToList()[0].Value).Count();
 
             //adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
-            adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
+            //adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
 
             FilterRequest linload = new FilterRequest() { Type = typeof(GeometricalLineLoad) };
             var lineloads = adapter.Pull(linload).ToList();

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -279,6 +279,12 @@ namespace RFEM_Toolkit_Test.Loading
             //adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
             adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
 
+            FilterRequest linload = new FilterRequest() { Type = typeof(GeometricalLineLoad) };
+            var lineloads = adapter.Pull(linload).ToList();
+            var lineload0 = (GeometricalLineLoad)lineloads[0];
+
+
+
 
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -229,6 +229,15 @@ namespace RFEM_Toolkit_Test.Loading
 
         }
 
+        [Test]
+        public void PullGeometricalLineload()
+        {
+            FilterRequest loadFilter = new FilterRequest() { Type = typeof(GeometricalLineLoad) };
+            var loads = adapter.Pull(loadFilter).ToList();
+            var l0 = (GeometricalLineLoad)loads[0];
+
+        }
+
         //[Test]
         //public void PushLineLoad()
         //{

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -253,23 +253,32 @@ namespace RFEM_Toolkit_Test.Loading
             FilterRequest loadFilter = new FilterRequest() { Type = typeof(Panel) };
             var panels = adapter.Pull(loadFilter).ToList();
             var panel0 = (Panel)panels[0];
+            var panel1 = (Panel)panels[1];
 
-            
 
-            Point p0 = new Point() { X = 0, Y = -10, Z = 0 };
+
+
+            Point p0 = new Point() { X = 0, Y = -1000, Z = 0 };
             Point p1 = new Point() { X = 0, Y = 10, Z = 0 };
 
+            Point p3 = new Point() { X = 1, Y = -2, Z = 0 };
+            Point p4 = new Point() { X = 1, Y = 2, Z = 0 };
 
 
 
-            GeometricalLineLoad geometricalLineLoad = new GeometricalLineLoad() { Name = "Free", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
-            geometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.SetPropertyValue(geometricalLineLoad, "Panels", new List<Panel>() { panel0 });
+            GeometricalLineLoad freeGeometricalLineLoad = new GeometricalLineLoad() { Name = "Free", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+
+            GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "NonFree", Location = BH.Engine.Geometry.Create.Line(p3, p4), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+
+            //freeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.SetPropertyValue(freeGeometricalLineLoad, "Panels"/*, new List<Panel>() { panel0, panel1 }*/);
 
 
             //((List<BH.oM.Structure.Elements.Panel>)geometricalLineLoad.CustomData.ToList()[0].Value).Count();
 
-            adapter.Push(new List<IObject>() { geometricalLineLoad });
+            adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
+            adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
+
 
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -29,6 +29,7 @@ using BH.oM.Structure.SectionProperties;
 using BH.Engine.Structure;
 using BH.oM.Structure.Loads;
 using BH.oM.Base;
+using System.Security.Policy;
 
 namespace RFEM_Toolkit_Test.Loading
 {
@@ -173,22 +174,49 @@ namespace RFEM_Toolkit_Test.Loading
             //AreaUniformlyDistributedLoad l0 = (AreaUniformlyDistributedLoad) areaLoadRead[0];
 
 
-            FilterRequest panelFilter = new FilterRequest() { Type = typeof(Panel) };
-            var panelReader = adapter.Pull(panelFilter).ToList();
-            Panel p0 = (Panel)panelReader[0];
-            Panel p1 = (Panel)panelReader[1];
-            Panel p2 = (Panel)panelReader[2];
+            //FilterRequest panelFilter = new FilterRequest() { Type = typeof(Panel) };
+            //var panelReader = adapter.Pull(panelFilter).ToList();
+            //Panel p0 = (Panel)panelReader[0];
+            //Panel p1 = (Panel)panelReader[1];
+            ////Panel p2 = (Panel)panelReader[2];
 
+            n1 = new Node() { Position = new Point() { X = 0, Y = 0, Z = 10 } };
+            n2 = new Node() { Position = new Point() { X = 10, Y = 0, Z = 10 } };
+            n3 = new Node() { Position = new Point() { X = 10, Y = 10, Z = 10 } };
+            n4 = new Node() { Position = new Point() { X = 0, Y = 10, Z = 10 } };
+
+            Edge e0 = new Edge() { Curve = BH.Engine.Geometry.Create.Line(n1.Position, n2.Position) };
+            Edge e1 = new Edge() { Curve = BH.Engine.Geometry.Create.Line(n2.Position, n3.Position) };
+            Edge e2 = new Edge() { Curve = BH.Engine.Geometry.Create.Line(n3.Position, n4.Position) };
+            Edge e3 = new Edge() { Curve = BH.Engine.Geometry.Create.Line(n4.Position, n1.Position) };
+
+            var concrete = BH.Engine.Library.Query.Match("Concrete", "C25/30", true, true) as IMaterialFragment;
+
+            BH.oM.Structure.SurfaceProperties.ConstantThickness surfaceProp = new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.3, Material = concrete };
+
+            Panel panel = new Panel() { ExternalEdges = new List<Edge>() {e0,e1,e2,e3}, Property = surfaceProp };
 
             Loadcase loadcaseWind = new Loadcase() { Name = "Windload", Nature = LoadNature.Wind, Number = 1 };
 
-            AreaUniformlyDistributedLoad areaLoad0 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(100000000000,0,0), new List<Panel>() { p1 });
-            AreaUniformlyDistributedLoad areaLoad1 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(0, 100000000000, 0), new List<Panel>() { p1 });
-            AreaUniformlyDistributedLoad areaLoad2 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(0, 0,100000000000), new List<Panel>() { p1 });
+
+            BHoMGroup<Node> nodeGroup = new BH.oM.Base.BHoMGroup<Node>() { Elements = new List<Node>() { n1 } };    
+            PointLoad pointLoad = new PointLoad() { Force= BH.Engine.Geometry.Create.Vector(100000000000, 0, 0),Loadcase=loadcaseWind,  Objects=nodeGroup};
 
 
-            adapter.Push(new List<AreaUniformlyDistributedLoad>() { areaLoad0,areaLoad1,areaLoad2 });
+            //adapter.Push(new List<IObject>() { pointLoad });
+            //adapter.Push(new List<IObject>() { panel, areaLoad0 });
+            adapter.Push(new List<IObject>() { panel });
 
+
+            FilterRequest panelFilter = new FilterRequest() { Type = typeof(Panel) };
+            var panelReader = adapter.Pull(panelFilter).ToList();
+            Panel p0 = (Panel)panelReader[0];
+
+            AreaUniformlyDistributedLoad areaLoad0 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(100000000000,0,0), new List<Panel>() { p0 });
+            
+            
+            
+            adapter.Push(new List<IObject>() { areaLoad0 });
 
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -150,10 +150,8 @@ namespace RFEM_Toolkit_Test.Loading
             n3 = new Node() { Position = new Point() { X = 0, Y = 10, Z = 10 } };
             n4 = new Node() { Position = new Point() { X = 10, Y = 10, Z = 10 } };
 
-
             Loadcase loadcaseDL0 = new Loadcase() { Name = "DeadLoad", Nature = LoadNature.Dead, Number = 1 };
             Loadcase loadcaseDL1 = new Loadcase() { Name = "Windload", Nature = LoadNature.Wind, Number = 1 };
-
 
             var pointGroup0 = new BH.oM.Base.BHoMGroup<Node>() { Elements = new List<Node> { n1, n2 } };
             var pointLoad0 = new BH.oM.Structure.Loads.PointLoad() { Objects = pointGroup0, Loadcase = loadcaseDL0, Moment = new Vector() { X = 100000, Y = 0, Z = 0 } };
@@ -161,9 +159,35 @@ namespace RFEM_Toolkit_Test.Loading
             var pointGroup1 = new BH.oM.Base.BHoMGroup<Node>() { Elements = new List<Node> { n3, n4 } };
             var pointLoad1 = new BH.oM.Structure.Loads.PointLoad() { Objects = pointGroup1, Loadcase = loadcaseDL1, Moment = new Vector() { X = 0, Y = 100000, Z = 0 } };
 
-
             adapter.Push(new List<ILoad>() { pointLoad0 });
             adapter.Push(new List<ILoad>() { pointLoad1 });
+
+        }
+
+
+        [Test]
+        public void PullSurfaceLoad()
+        {
+            //FilterRequest loadFilter = new FilterRequest() { Type = typeof(AreaUniformlyDistributedLoad) };
+            //var areaLoadRead = adapter.Pull(loadFilter).ToList();
+            //AreaUniformlyDistributedLoad l0 = (AreaUniformlyDistributedLoad) areaLoadRead[0];
+
+
+            FilterRequest panelFilter = new FilterRequest() { Type = typeof(Panel) };
+            var panelReader = adapter.Pull(panelFilter).ToList();
+            Panel p0 = (Panel)panelReader[0];
+            Panel p1 = (Panel)panelReader[1];
+            Panel p2 = (Panel)panelReader[2];
+
+
+            Loadcase loadcaseWind = new Loadcase() { Name = "Windload", Nature = LoadNature.Wind, Number = 1 };
+
+            AreaUniformlyDistributedLoad areaLoad0 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(100000000000,0,0), new List<Panel>() { p1 });
+            AreaUniformlyDistributedLoad areaLoad1 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(0, 100000000000, 0), new List<Panel>() { p1 });
+            AreaUniformlyDistributedLoad areaLoad2 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(0, 0,100000000000), new List<Panel>() { p1 });
+
+
+            adapter.Push(new List<AreaUniformlyDistributedLoad>() { areaLoad0,areaLoad1,areaLoad2 });
 
 
         }

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -33,6 +33,8 @@ using System.Security.Policy;
 using BH.oM.Adapters.RFEM6.BHoMDataStructure.SupportDatastrures;
 using BH.oM.Adapters.RFEM6.Fragments.Enums;
 using BH.Engine.Spatial;
+using BH.Engine.Base;
+using BH.oM.Analytical.Elements;
 
 namespace RFEM_Toolkit_Test.Loading
 {
@@ -55,6 +57,9 @@ namespace RFEM_Toolkit_Test.Loading
         BarRelease release3;
         BarRelease release4;
         Bar bar;
+
+
+
 
 
         [OneTimeSetUp]
@@ -197,13 +202,13 @@ namespace RFEM_Toolkit_Test.Loading
 
             BH.oM.Structure.SurfaceProperties.ConstantThickness surfaceProp = new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.3, Material = concrete };
 
-            Panel panel = new Panel() { ExternalEdges = new List<Edge>() {e0,e1,e2,e3}, Property = surfaceProp };
+            Panel panel = new Panel() { ExternalEdges = new List<Edge>() { e0, e1, e2, e3 }, Property = surfaceProp };
 
             Loadcase loadcaseWind = new Loadcase() { Name = "Windload", Nature = LoadNature.Wind, Number = 1 };
 
 
-            BHoMGroup<Node> nodeGroup = new BH.oM.Base.BHoMGroup<Node>() { Elements = new List<Node>() { n1 } };    
-            PointLoad pointLoad = new PointLoad() { Force= BH.Engine.Geometry.Create.Vector(100000000000, 0, 0),Loadcase=loadcaseWind,  Objects=nodeGroup};
+            BHoMGroup<Node> nodeGroup = new BH.oM.Base.BHoMGroup<Node>() { Elements = new List<Node>() { n1 } };
+            PointLoad pointLoad = new PointLoad() { Force = BH.Engine.Geometry.Create.Vector(100000000000, 0, 0), Loadcase = loadcaseWind, Objects = nodeGroup };
 
 
             //adapter.Push(new List<IObject>() { pointLoad });
@@ -215,10 +220,10 @@ namespace RFEM_Toolkit_Test.Loading
             var panelReader = adapter.Pull(panelFilter).ToList();
             Panel p0 = (Panel)panelReader[0];
 
-            AreaUniformlyDistributedLoad areaLoad0 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(100000000000,0,0), new List<Panel>() { p0 });
-            
-            
-            
+            AreaUniformlyDistributedLoad areaLoad0 = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcaseWind, BH.Engine.Geometry.Create.Vector(100000000000, 0, 0), new List<Panel>() { p0 });
+
+
+
             adapter.Push(new List<IObject>() { areaLoad0 });
 
         }
@@ -240,7 +245,7 @@ namespace RFEM_Toolkit_Test.Loading
             var l0 = (GeometricalLineLoad)loads[0];
 
         }
-        
+
         [Test]
         public void PullBarload()
         {
@@ -253,37 +258,52 @@ namespace RFEM_Toolkit_Test.Loading
         [Test]
         public void PushFreeLineLoadload()
         {
-            FilterRequest loadFilter = new FilterRequest() { Type = typeof(Panel) };
-            var panels = adapter.Pull(loadFilter).ToList();
-            var panel0 = (Panel)panels[0];
-            //var panel1 = (Panel)panels[1];
+            Point p0 = new Point() { X = -10, Y = -10, Z = 0 };
+            Point p1 = new Point() { X = -10, Y = 10, Z = 0 };
+            Point p2 = new Point() { X = 10, Y = 10, Z = 0 };
+            Point p3 = new Point() { X = 10, Y = -10, Z = 0 };
 
 
 
 
-            Point p0 = new Point() { X = 0, Y = -1000, Z = 0 };
-            Point p1 = new Point() { X = 0, Y = 10, Z = 0 };
+            // Create Panel 1
+            Edge edge1 = new Edge() { Curve = new Line() { Start = p0, End = p1 } };
+            Edge edge2 = new Edge() { Curve = new Line() { Start = p1, End = p2 } };
+            Edge edge3 = new Edge() { Curve = new Line() { Start = p2, End = p3 } };
+            Edge edge4 = new Edge() { Curve = new Line() { Start = p3, End = p0 } };
+            var concrete = BH.Engine.Library.Query.Match("Concrete", "C25/30", true, true) as IMaterialFragment;
+            //var steel = BH.Engine.Library.Query.Match("Steel", "S235", true, true) as IMaterialFragment;
+            Panel panel0 = new Panel() { ExternalEdges = new List<Edge>() { edge1, edge2, edge3, edge4 }, Openings = new List<Opening>() { }, Property = new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.1, Material = concrete } };
 
-            Point p3 = panel0.ExternalEdges.First().Curve.ControlPoints().First();
-            Point p4 = panel0.ExternalEdges.First().Curve.ControlPoints().Last();
 
-            GeometricalLineLoad freeGeometricalLineLoad = new GeometricalLineLoad() { Name = "name1", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+          
+            Point pLine0 = new Point() { X = 0, Y = -10, Z = 0 };
+            Point pLine1 = new Point() { X = 0, Y = 10, Z = 0 };
+
+            Point pLine2 = panel0.ExternalEdges.First().Curve.ControlPoints().First();
+            Point pline3 = panel0.ExternalEdges.First().Curve.ControlPoints().Last();
+
+            //GeometricalLineLoad freeGeometricalLineLoad = new GeometricalLineLoad() { Name = "name1", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+            GeometricalLineLoad freeGeometricalLineLoad = BH.Engine.Structure.Create.GeometricalLineLoad(new Line() { Start = pLine0, End = pLine1 }, new Loadcase() { Nature = LoadNature.Wind }, new Vector() { X = 0, Y = 0, Z = 100000 }, null, new List<Panel>() { panel0.ShallowClone() }, "LineloadNumber1");
 
             //GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "name2", Location = BH.Engine.Geometry.Create.Line(p3, p4), MomentA = BH.Engine.Geometry.Create.Vector(0, 0, 0), MomentB = BH.Engine.Geometry.Create.Vector(0, 0, 1000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
-            GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "name2", Location = BH.Engine.Geometry.Create.Line(p3, p4), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 0), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 1000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+            GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "name2", Location = BH.Engine.Geometry.Create.Line(pLine2, pline3), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 0), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 1000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
             freeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.AddFragment(freeGeometricalLineLoad, new RFEM6GeometricalLineLoadTypes() { geometrialLineLoadType = GeometricalLineLoadTypesEnum.FreeLineLoad }, false);
 
-            //nonFreeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.AddFragment(nonFreeGeometricalLineLoad, new RFEM6GeometricalLineLoadTypes() {geometrialLineLoadType=GeometricalLineLoadTypesEnum.NonFreeLineLoad }, false);
+            nonFreeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.AddFragment(nonFreeGeometricalLineLoad, new RFEM6GeometricalLineLoadTypes() { geometrialLineLoadType = GeometricalLineLoadTypesEnum.NonFreeLineLoad }, false);
 
             //freeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.SetPropertyValue(freeGeometricalLineLoad, "Panels"/*, new List<Panel>() { panel0, panel1 }*/);
 
 
             //((List<BH.oM.Structure.Elements.Panel>)geometricalLineLoad.CustomData.ToList()[0].Value).Count();
 
-            adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
+            adapter.Push(new List<IObject>() { panel0.DeepClone()});
+            //adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
             adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
+
+            //adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
 
             //FilterRequest linload = new FilterRequest() { Type = typeof(GeometricalLineLoad) };
             //var lineloads = adapter.Pull(linload).ToList();

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Loads.cs
@@ -269,14 +269,14 @@ namespace RFEM_Toolkit_Test.Loading
 
             GeometricalLineLoad freeGeometricalLineLoad = new GeometricalLineLoad() { Name = "Free", Location = BH.Engine.Geometry.Create.Line(p0, p1), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
-            GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "NonFree", Location = BH.Engine.Geometry.Create.Line(p3, p4), ForceA = BH.Engine.Geometry.Create.Vector(0, 0, 100000000000), ForceB = BH.Engine.Geometry.Create.Vector(0, 0, 100000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
+            GeometricalLineLoad nonFreeGeometricalLineLoad = new GeometricalLineLoad() { Name = "NonFree", Location = BH.Engine.Geometry.Create.Line(p3, p4), MomentA = BH.Engine.Geometry.Create.Vector(0, 0, 0), MomentB = BH.Engine.Geometry.Create.Vector(0, 0, 1000), Loadcase = new Loadcase() { Nature = LoadNature.Wind } };
 
             //freeGeometricalLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.SetPropertyValue(freeGeometricalLineLoad, "Panels"/*, new List<Panel>() { panel0, panel1 }*/);
 
 
             //((List<BH.oM.Structure.Elements.Panel>)geometricalLineLoad.CustomData.ToList()[0].Value).Count();
 
-            adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
+            //adapter.Push(new List<IObject>() { freeGeometricalLineLoad });
             adapter.Push(new List<IObject>() { nonFreeGeometricalLineLoad });
 
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Panel.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Panel.cs
@@ -1,0 +1,103 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using BH.Adapter.RFEM6;
+using BH.Engine.Base;
+using BH.Engine.Geometry;
+using BH.oM.Analytical.Elements;
+using BH.oM.Data.Requests;
+using BH.oM.Geometry;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.MaterialFragments;
+using BH.oM.Structure.SectionProperties;
+
+namespace RFEM_Toolkit_Test.Elements
+{
+
+
+    public class PushPullPanels0
+    {
+        RFEM6Adapter adapter;
+        RFEMPanelComparer comparer;
+        Opening opening1;
+        Opening opening2;
+        Panel panel1;
+        Panel panel2;
+        Edge edge1;
+        Edge edge2;
+        Edge edge3;
+        Edge edge4;
+        Edge edge5;
+        Edge edge6;
+        Edge edge7;
+        Edge edge8;
+        Edge edge9;
+        Edge edge10;
+        Edge edge11;
+        Edge edge12;
+
+
+        [OneTimeSetUp]
+        public void InitializeOpenings()
+        {
+            adapter = new RFEM6Adapter(true);
+        }
+
+        //[TearDown]
+        //public void TearDown()
+        //{
+        //    adapter.Wipeout();
+        //}
+
+        [Test]
+        public void pushTwoAdjecentPanels()
+        {
+      
+            var concrete = BH.Engine.Library.Query.Match("Concrete", "C25/30", true, true) as IMaterialFragment;
+            var steel = BH.Engine.Library.Query.Match("Steel", "S235", true, true) as IMaterialFragment;
+
+            panel1 = new Panel() { ExternalEdges = new List<Edge>() { edge4, edge5, edge6, edge7 }, Openings = new List<Opening>() { opening1 }, Property = new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.5, Material = concrete } };
+
+            Polyline outline0 = new Polyline() { ControlPoints = new List<Point>() { new Point() { X = 0, Y = 0, Z = 0 }, new Point() { X = 10, Y = 0, Z = 0 }, new Point() { X = 10, Y = 10, Z = 0 }, new Point() { X = 0, Y = 10, Z = 0 } } };
+            panel1 = BH.Engine.Structure.Create.Panel((ICurve)outline0.Close(), null, new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.1, Material = concrete }, "");
+
+            Polyline outline1 = new Polyline() { ControlPoints = new List<Point>() { new Point() { X = 10, Y = 0, Z = 0 }, new Point() { X = 20, Y = 0, Z = 0 }, new Point() { X = 20, Y = 10, Z = 0 }, new Point() { X = 10, Y = 10, Z = 0 } } };
+            panel2 = BH.Engine.Structure.Create.Panel((ICurve)outline1.Close().Flip(), null, new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.1, Material = concrete }, "");
+
+
+            // Push panel 
+            adapter.Push(new List<Panel>() { panel1, panel2 });
+
+            //// Pull it
+            //FilterRequest panelFilter = new FilterRequest() { Type = typeof(Panel) };
+            //var panelPulled = adapter.Pull(panelFilter).ToList();
+            //Panel pp = (Panel)panelPulled[0];
+
+            //// Check
+            //Assert.IsNotNull(pp);
+            //Assert.IsTrue(comparer.Equals(pp, panel1));
+        }
+
+
+    }
+}
+
+

--- a/RFEM6_Adapter/AdapterActions/TwoStagePushErrorMessageCheck.cs
+++ b/RFEM6_Adapter/AdapterActions/TwoStagePushErrorMessageCheck.cs
@@ -43,9 +43,16 @@ namespace BH.Adapter.RFEM6
 
             if (hasBar && hasBarLoad)
             {
-                BH.Engine.Base.Compute.RecordError("Pushed Set has both Bars and Loads. Please make sure that Bars and BarUDLs are pushed seperatly. First Push parts, next push BarUDL!");
+                BH.Engine.Base.Compute.RecordError("Pushed Set has both Bars and Loads. Please make sure that Bars and BarUDLs are pushed seperatly. First Push bars, next push BarUDL!");
             }
 
+            bool hasPanel = obj.Any(o => o is Panel);
+            bool hasAreaLoad = obj.Any(o => o is AreaUniformlyDistributedLoad);
+
+            if (hasPanel && hasAreaLoad)
+            {
+                BH.Engine.Base.Compute.RecordError("Pushed Set has both Panels and AreaUniformlyDistributedLoad. Please make sure that Panels and AreaUniformlyDistributedLoad are pushed seperatly. First Push Panels, next push AreaUniformlyDistributedLoads!");
+            }
 
         }
     }

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Geometry/Panel.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Geometry/Panel.cs
@@ -46,6 +46,8 @@ namespace BH.Adapter.RFEM6
             {
 
                 rfModel.surface surface = bhPanel.ToRFEM6();
+                m_PanelIDdict.Add(bhPanel, bhPanel.GetRFEM6ID());
+
 
                 m_Model.set_surface(surface);
 

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -66,8 +66,14 @@ namespace BH.Adapter.RFEM6
                     continue;
                 }
 
-                object nodalLoadType = MomentOfForceLoad(bhLoad);
-                if (nodalLoadType is null) continue;
+
+                    object nodalLoadType=null;
+                if (!(bhLoad is GeometricalLineLoad))
+                {
+                    nodalLoadType = MomentOfForceLoad(bhLoad);
+                    if (nodalLoadType is null) continue;
+                }
+
 
                 if (bhLoad is BarUniformlyDistributedLoad)
                 {
@@ -143,14 +149,19 @@ namespace BH.Adapter.RFEM6
                     else
                     {
                         // Hadling Free Line Loads
+
+                        if ((bhLoad as GeometricalLineLoad).MomentA.Length() > 0 || (bhLoad as GeometricalLineLoad).MomentB.Length() > 0)
+                        {
+                            BH.Engine.Base.Compute.RecordError($"Free Line Loads do not allow Moments. Please remove the Moment Vector from the Load {bhLoad}!");
+                            continue;
+                        }
                         int[] currrSurfaceIds = new int[] { };
 
                         UpdateLoadIdDictionary(bhLoad);
-                        if (surfaceIds.Count() == 0 && (bhLoad as GeometricalLineLoad).Objects is null)
+                        if (surfaceIds.Count() == 0 && (bhLoad as GeometricalLineLoad).Objects is null|| (bhLoad as GeometricalLineLoad).Objects.Elements.Count == 0||((bhLoad as GeometricalLineLoad).Objects.Elements.First() is null))
                         {
                             surfaceIds = m_Model.get_all_object_numbers(object_types.E_OBJECT_TYPE_SURFACE, 0);
-                        }
-                        if (!((bhLoad as GeometricalLineLoad).Objects is null))
+                        } if (!((bhLoad as GeometricalLineLoad).Objects is null)&& (bhLoad as GeometricalLineLoad).Objects.Elements.Count()!=0 && !((bhLoad as GeometricalLineLoad).Objects.Elements.First() is null))
                         {
                             currrSurfaceIds = (bhLoad as GeometricalLineLoad).Objects.Elements.ToList().Select(e => (e as Panel).GetRFEM6ID()).ToArray();
 

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -36,6 +36,7 @@ using System.Security.Cryptography;
 using BH.Engine.Base;
 using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
 using BH.Engine.Structure;
+using BH.oM.Adapters.RFEM6;
 
 namespace BH.Adapter.RFEM6
 {
@@ -82,6 +83,8 @@ namespace BH.Adapter.RFEM6
 
                 if (bhLoad is AreaUniformlyDistributedLoad)
                 {
+                    //Dictionary<int, Panel> supportMap = this.GetCachedOrReadAsDictionary<int, Panel>();
+
                     updateLoadIdDictionary(bhLoad);
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
                     surface_load rfemAreaLoad = (bhLoad as AreaUniformlyDistributedLoad).ToRFEM6(id);
@@ -115,8 +118,10 @@ namespace BH.Adapter.RFEM6
                     member_load member_load = (bhLoad as BarUniformlyDistributedLoad).ToRFEM6((member_load_load_type)nodalLoadType, id);
                     var rfMemberLoad = member_load;
                     m_Model.set_member_load(bhLoad.Loadcase.GetRFEM6ID(), rfMemberLoad);
+                    continue;
                 }
-                else if (bhLoad is PointLoad)
+
+                if (bhLoad is PointLoad)
                 {
                     //nodal_load_load_type nodalLoadType = MomentOfForceLoad(bhLoad as PointLoad);
                     //if (nodalLoadType == 0) continue;
@@ -125,7 +130,7 @@ namespace BH.Adapter.RFEM6
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
                     nodal_load rfPointLoad = (bhLoad as PointLoad).ToRFEM6((nodal_load_load_type)nodalLoadType, id);
                     m_Model.set_nodal_load(bhLoad.Loadcase.GetRFEM6ID(), rfPointLoad);
-
+                    continue;
 
                 }
 

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -97,6 +97,8 @@ namespace BH.Adapter.RFEM6
 
                 if (bhLoad is BarUniformlyDistributedLoad)
                 {
+                    if (!DirectionVectorIsXYZAxisParallel((bhLoad as BarUniformlyDistributedLoad).Force))
+                    {
 
                     if (!DirectionVectorIsXYZAxisParallel((bhLoad as BarUniformlyDistributedLoad).Force))
                     {

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -80,6 +80,15 @@ namespace BH.Adapter.RFEM6
             {
 
 
+                if (bhLoad is AreaUniformlyDistributedLoad)
+                {
+                    updateLoadIdDictionary(bhLoad);
+                    int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
+                    surface_load rfemAreaLoad = (bhLoad as AreaUniformlyDistributedLoad).ToRFEM6(id);
+                    m_Model.set_surface_load(bhLoad.Loadcase.GetRFEM6ID(), rfemAreaLoad);
+                    continue;
+                }
+
                 object nodalLoadType = MomentOfForceLoad(bhLoad);
                 if (nodalLoadType is null) continue;
 
@@ -114,7 +123,7 @@ namespace BH.Adapter.RFEM6
 
                     UpdateLoadIdDictionary(bhLoad);
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
-                    nodal_load rfPointLoad = (bhLoad as PointLoad).ToRFEM6((nodal_load_load_type) nodalLoadType, id);
+                    nodal_load rfPointLoad = (bhLoad as PointLoad).ToRFEM6((nodal_load_load_type)nodalLoadType, id);
                     m_Model.set_nodal_load(bhLoad.Loadcase.GetRFEM6ID(), rfPointLoad);
 
 
@@ -132,12 +141,7 @@ namespace BH.Adapter.RFEM6
 
                 //}
 
-                //else if (bhLoad is AreaUniformlyDistributedLoad) {
 
-                //    surface_load rfemAreaLoad=(bhLoad as AreaUniformlyDistributedLoad).ToRFEM6();
-                //    m_Model.set_surface_load(bhLoad.Loadcase.GetRFEM6ID(), rfemAreaLoad);
-
-                //}
 
             }
 
@@ -160,7 +164,7 @@ namespace BH.Adapter.RFEM6
                 momentHasBeenSet = !(bhPointLoad.Moment.X == 0 && bhPointLoad.Moment.Y == 0 && bhPointLoad.Moment.Z == 0);
                 forceHasBeenSet = !(bhPointLoad.Force.X == 0 && bhPointLoad.Force.Y == 0 && bhPointLoad.Force.Z == 0);
                 //bhLoadType = nodal_load_load_type.LOAD_TYPE_FORCE;
-                bhLoadType = forceHasBeenSet==true? nodal_load_load_type.LOAD_TYPE_FORCE: nodal_load_load_type.LOAD_TYPE_MOMENT;
+                bhLoadType = forceHasBeenSet == true ? nodal_load_load_type.LOAD_TYPE_FORCE : nodal_load_load_type.LOAD_TYPE_MOMENT;
 
             }
             else

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -97,9 +97,7 @@ namespace BH.Adapter.RFEM6
 
                 if (bhLoad is BarUniformlyDistributedLoad)
                 {
-                    if (!DirectionVectorIsXYZAxisParallel((bhLoad as BarUniformlyDistributedLoad).Force))
-                    {
-
+                   
                     if (!DirectionVectorIsXYZAxisParallel((bhLoad as BarUniformlyDistributedLoad).Force))
                     {
 

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -85,7 +85,7 @@ namespace BH.Adapter.RFEM6
                 {
                     //Dictionary<int, Panel> supportMap = this.GetCachedOrReadAsDictionary<int, Panel>();
 
-                    updateLoadIdDictionary(bhLoad);
+                    UpdateLoadIdDictionary(bhLoad);
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
                     surface_load rfemAreaLoad = (bhLoad as AreaUniformlyDistributedLoad).ToRFEM6(id);
                     m_Model.set_surface_load(bhLoad.Loadcase.GetRFEM6ID(), rfemAreaLoad);

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -45,37 +45,6 @@ namespace BH.Adapter.RFEM6
 
         private bool CreateCollection(IEnumerable<ILoad> bhLoads)
         {
-            ////Checking presence of GeometricalLineLoads and getting all line numbers if yes it is required to read all lines from RFEM6
-            //NodeDistanceComparer nodeDistanceComparer = new NodeDistanceComparer(3);
-            //Dictionary<Node, Dictionary<Node, int>> nestedNodeToIDMap = new Dictionary<Node, Dictionary<Node, int>>(nodeDistanceComparer);
-            //List<rfModel.line> allLineNumbers = new List<rfModel.line>();
-
-            ////If necessary fill the NodeToIDMap
-            //if (bhLoads.Where(l => l is GeometricalLineLoad).ToList().Count() > 0)
-            //{
-
-            //    rfModel.object_with_children[] lineNumber = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LINE);
-            //    allLineNumbers = lineNumber.Length > 1 ? lineNumber.ToList().Select(n => m_Model.get_line(n.no)).ToList().ToList() : new List<rfModel.line>();
-
-            //    foreach (rfModel.line l in allLineNumbers)
-            //    {
-
-            //        Node n0 = m_Model.get_node(l.definition_nodes[0]).FromRFEM();
-            //        Node n1 = m_Model.get_node(l.definition_nodes[1]).FromRFEM();
-
-            //        if (!nestedNodeToIDMap.ContainsKey(n0))
-            //        {
-            //            Dictionary<Node, int> innterDictionary = new Dictionary<Node, int>(nodeDistanceComparer);
-            //            innterDictionary.Add(n1, l.no);
-            //            nestedNodeToIDMap.Add(n0, innterDictionary);
-            //        }
-            //        else
-            //        {
-            //            nestedNodeToIDMap[n0].Add(n1, l.no);
-            //        }
-            //    }
-
-            //}
 
             foreach (ILoad bhLoad in bhLoads)
             {
@@ -83,7 +52,6 @@ namespace BH.Adapter.RFEM6
 
                 if (bhLoad is AreaUniformlyDistributedLoad)
                 {
-                    //Dictionary<int, Panel> supportMap = this.GetCachedOrReadAsDictionary<int, Panel>();
 
                     UpdateLoadIdDictionary(bhLoad);
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
@@ -97,7 +65,7 @@ namespace BH.Adapter.RFEM6
 
                 if (bhLoad is BarUniformlyDistributedLoad)
                 {
-                   
+
                     if (!DirectionVectorIsXYZAxisParallel((bhLoad as BarUniformlyDistributedLoad).Force))
                     {
 
@@ -123,9 +91,7 @@ namespace BH.Adapter.RFEM6
 
                 if (bhLoad is PointLoad)
                 {
-                    //nodal_load_load_type nodalLoadType = MomentOfForceLoad(bhLoad as PointLoad);
-                    //if (nodalLoadType == 0) continue;
-
+                    
                     UpdateLoadIdDictionary(bhLoad);
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
                     nodal_load rfPointLoad = (bhLoad as PointLoad).ToRFEM6((nodal_load_load_type)nodalLoadType, id);
@@ -222,12 +188,12 @@ namespace BH.Adapter.RFEM6
         //private void BarLoadErrorMessage(Vector vector) {
 
         //    if (vector.X != 0 && (!(vector.Y == 0 || vector.Z == 0))){ 
-            
+
         //        BH.Engine.Base.Compute.RecordWarning($"The Load Vector {vector} is not aligned with the X, Y or Z axis. Please make sure your Barload is either parallel to the X, Y or Z axis!");
-            
+
         //    }    
 
-        
+
         //}
 
         private bool DirectionVectorIsXYZAxisParallel(Vector vector)

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -241,7 +241,7 @@ namespace BH.Adapter.RFEM6
 
             if (!momentHasBeenSet && !forceHasBeenSet)
             {
-
+                BH.Engine.Base.Compute.RecordError($"The Load {bhLoad} does not include Vectors representing Moments or Forces!");
                 return null;
             }
 
@@ -258,7 +258,7 @@ namespace BH.Adapter.RFEM6
             }
             else
             {
-
+                BH.Engine.Base.Compute.RecordError($"Something went wrong! Please Check the Load {bhLoad}!");
                 return null;
             }
 

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -64,7 +64,11 @@ namespace BH.Adapter.RFEM6
                     UpdateLoadIdDictionary(bhLoad);
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
                     surface_load rfemAreaLoad = (bhLoad as AreaUniformlyDistributedLoad).ToRFEM6(id);
+                    var currrSurfaceIds = (bhLoad as AreaUniformlyDistributedLoad).Objects.Elements.ToList().Select(e => m_PanelIDdict[e as Panel]).ToArray();
+                    rfemAreaLoad.surfaces = currrSurfaceIds;
+                    //rfemAreaLoad. = currrSurfaceIds;
                     m_Model.set_surface_load(bhLoad.Loadcase.GetRFEM6ID(), rfemAreaLoad);
+
                     continue;
                 }
 
@@ -178,7 +182,9 @@ namespace BH.Adapter.RFEM6
                         }
                         if (!((bhLoad as GeometricalLineLoad).Objects is null) && (bhLoad as GeometricalLineLoad).Objects.Elements.Count() != 0 && !((bhLoad as GeometricalLineLoad).Objects.Elements.First() is null))
                         {
-                            currrSurfaceIds = (bhLoad as GeometricalLineLoad).Objects.Elements.ToList().Select(e => (e as Panel).GetRFEM6ID()).ToArray();
+                            //currrSurfaceIds = (bhLoad as GeometricalLineLoad).Objects.Elements.ToList().Select(e => (e as Panel).GetRFEM6ID()).ToArray();
+                            currrSurfaceIds = (bhLoad as GeometricalLineLoad).Objects.Elements.ToList().Select(e =>m_PanelIDdict[e as Panel]).ToArray();
+
 
                         }
                         else

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Panel.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Panel.cs
@@ -84,16 +84,16 @@ namespace BH.Adapter.RFEM6
             }
 
             //ComparerPoin
-            //foreach (rfModel.surface rfPanel in allRfPanels)
-            //{
+            foreach (rfModel.surface rfPanel in allRfPanels)
+            {
 
-            //    var bhPanel= rfPanel.FromRFEM(edges, surfaceProperties, surfaceOpeningIdDicionary[rfPanel.no], surfaceOpening);
-            //    bhPanels.Add(bhPanel);
-            //    HashSet<Point> panelPointSet= new HasSet<Point> { bhPanel.ExternalEdges.Select(b => b.Curve.ControlPoints()) };
+                var bhPanel = rfPanel.FromRFEM(edges, surfaceProperties, surfaceOpeningIdDicionary[rfPanel.no], surfaceOpening);
+                bhPanels.Add(bhPanel);
+                //HashSet<Point> panelPointSet = new HasSet<Point> { bhPanel.ExternalEdges.Select(b => b.Curve.ControlPoints()) };
 
-            //}
+            }
 
-            
+
 
             return bhPanels;
         }

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Panel.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Panel.cs
@@ -82,12 +82,15 @@ namespace BH.Adapter.RFEM6
                 surfaceOpeningIdDicionary.Add(s, openingIds);
 
             }
-
+           
             //ComparerPoin
+            m_PanelIDdict.Clear();
             foreach (rfModel.surface rfPanel in allRfPanels)
             {
 
                 var bhPanel = rfPanel.FromRFEM(edges, surfaceProperties, surfaceOpeningIdDicionary[rfPanel.no], surfaceOpening);
+                //m_PanelIDdict.Add(bhPanel, rfPanel.no);
+                m_PanelIDdict[bhPanel]=rfPanel.no;
                 bhPanels.Add(bhPanel);
                 //HashSet<Point> panelPointSet = new HasSet<Point> { bhPanel.ExternalEdges.Select(b => b.Curve.ControlPoints()) };
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -116,7 +116,7 @@ namespace BH.Adapter.RFEM6
                     continue;
                 }
 
-                loads.Add(surfaceLoad.FromRFEM(loadCaseMap[surfaceLoad.load_case], panels ));
+                loads.Add(surfaceLoad.FromRFEM(loadCaseMap[surfaceLoad.load_case], panels));
 
             }
 
@@ -139,8 +139,18 @@ namespace BH.Adapter.RFEM6
 
             foreach (rfModel.free_line_load freeLineLoad in foundFreeLineLoads)
             {
+                List<Panel> panelList;
+                if (freeLineLoad.surfaces.ToList().First() == 0)
+                {
+                    panelList = new List<Panel>();
+                }
+                else
+                {
 
-                loads.Add(freeLineLoad.FromRFEM(loadCaseMap[freeLineLoad.load_case], freeLineLoad.surfaces.ToList().Select(s => panelMap[s]).ToList()));
+                    panelList = freeLineLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
+
+                }
+                loads.Add(freeLineLoad.FromRFEM(loadCaseMap[freeLineLoad.load_case], panelList));
 
             }
 
@@ -148,7 +158,8 @@ namespace BH.Adapter.RFEM6
         }
 
 
-        private void UpdateLoadIdDictionary(ILoad load) { 
+        private void UpdateLoadIdDictionary(ILoad load)
+        {
 
 
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -51,12 +51,7 @@ namespace BH.Adapter.RFEM6
 
             rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_MEMBER_LOAD);
 
-            //IEnumerable<rfModel.member_load> foundLoadCases = numbers.ToList().Select(n => m_Model.get_member_load(n.no, n.children[0]));
-            //IEnumerable<rfModel.member_load> foundLoadCases = numbers.ToList().Select(n => m_Model.get_member_load(n.children[0], n.no));
-
             IEnumerable<rfModel.member_load> foundLoadCases = numbers.SelectMany(n => n.children.ToList().Select(child => m_Model.get_member_load(child, n.no)));
-
-
 
             List<ILoad> loadCases = new List<ILoad>();
             foreach (rfModel.member_load memberLoad in foundLoadCases)

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -167,9 +167,7 @@ namespace BH.Adapter.RFEM6
         //}
 
 
-        private void updateLoadIdDictionary(ILoad load)
-        {
-
+      
         //    return loads;
         //}
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -160,8 +160,8 @@ namespace BH.Adapter.RFEM6
 
         private void UpdateLoadIdDictionary(ILoad load)
         {
-
-
+          
+         
 
             if (m_LoadcaseLoadIdDict.TryGetValue(load.Loadcase, out Dictionary<String, int> loadIdDict))
             {
@@ -189,6 +189,7 @@ namespace BH.Adapter.RFEM6
                 var d = new Dictionary<string, int>();
                 d.Add(load.GetType().Name, m_Model.get_first_free_number(load.GetType().ToRFEM6().Value, load.Loadcase.GetRFEM6ID()));
                 m_LoadcaseLoadIdDict.Add(load.Loadcase, d);
+                }
 
             }
 
@@ -197,4 +198,4 @@ namespace BH.Adapter.RFEM6
         }
 
     }
-}
+

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -152,59 +152,10 @@ namespace BH.Adapter.RFEM6
             return loads;
         }
 
-    
 
-        //private List<ILoad> ReadLineLoad(List<string> ids = null)
-        //{
-        //    //Find all possible Load cases
-        //    Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
-        //    //List<int> loadCaseIds = loadCaseMap.Keys.ToList();
-        //    Dictionary<int, Edge> lineMap = this.GetCachedOrReadAsDictionary<int, Edge>();
+        private void UpdateLoadIdDictionary(ILoad load) { 
 
 
-        //    rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD);
-
-        //    IEnumerable<rfModel.line_load> foundLineLoad = numbers.ToList().Select(n => m_Model.get_line_load(n.children[0], n.no));
-
-
-        //    List<ILoad> loads = new List<ILoad>();
-        //    foreach (rfModel.line_load lineLoad in foundLineLoad)
-        //    {
-        //        List<Edge> allEdges = lineLoad.lines.ToList().Select(l => lineMap[l]).ToList();
-        //        List<Edge> lineEdges = allEdges.Where(e => ((e.Curve is Line) || (e.Curve is Polyline && (e.Curve as Polyline).ControlPoints.Count == 2))).ToList();
-
-        //        // if One of the edges is not a line, skip this load
-        //        if (!(lineEdges?.Count() != null || lineEdges?.Count() > 0)) continue;
-
-        //        //if the load is over the total length of the line, skip this load
-        //        //if (lineLoad.distance_a_absolute!=0||lineLoad.distance_b_absolute!=0||lineLoad.distance_c_absolute!=0) continue;
-        //        if (lineLoad.load_distribution != rfModel.line_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM) continue;
-
-
-        //        foreach (Edge lineEdge in lineEdges)
-        //        {
-
-        //            loads.Add(lineLoad.FromRFEM(loadCaseMap[lineLoad.load_case], lineEdge));
-
-        //        }
-
-        //    }
-
-        //    return loads;
-        //}
-
-
-<<<<<<< HEAD
-      
-        //    return loads;
-        //}
-
-        private void UpdateLoadIdDictionary(ILoad load)
-=======
-
-        private void updateLoadIdDictionary(ILoad load)
->>>>>>> 4a96e76 (...)
-        {
 
             if (m_LoadcaseLoadIdDict.TryGetValue(load.Loadcase, out Dictionary<String, int> loadIdDict))
             {

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -177,12 +177,18 @@ namespace BH.Adapter.RFEM6
 
             foreach (rfModel.line_load lineLoad in foundFreeLineLoads)
             {
-                ICurve c = edgeDictionary[lineLoad.lines[0]].Curve;
-                Line line;
-                if (c.ControlPoints().Count == 2) { line = new Line() { Start = c.ControlPoints().First(), End = c.ControlPoints().Last() }; }
-                else { continue; }
+                
+                List<ICurve> curveList = lineLoad.lines.ToList().Select(l => edgeDictionary[l].Curve).Where(cu=> (cu is Line)||(cu is Polyline && cu.ControlPoints().Count==2) ).ToList();
+                List<Line> lines = curveList.Select(k => new Line() { Start = k.ControlPoints().First(), End = k.ControlPoints().First() }).ToList();
+                lines.ForEach(l => loads.Add(lineLoad.FromRFEM(loadCaseMap[lineLoad.load_case], l)));
 
-                loads.Add(lineLoad.FromRFEM(loadCaseMap[lineLoad.load_case], line));
+
+                //ICurve c = edgeDictionary[lineLoad.lines[0]].Curve;
+                //Line line;
+                //if (c.ControlPoints().Count == 2) { line = new Line() { Start = c.ControlPoints().First(), End = c.ControlPoints().Last() }; }
+                //else { continue; }
+
+                //loads.Add(lineLoad.FromRFEM(loadCaseMap[lineLoad.load_case], line));
 
             }
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -127,6 +127,33 @@ namespace BH.Adapter.RFEM6
 
             return loads;
         }
+
+        private List<ILoad> ReadLineLoad(List<string> ids = null)
+        {
+            List<ILoad> loads = new List<ILoad>();
+
+            Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
+            Dictionary<int, Panel> panelMap = this.GetCachedOrReadAsDictionary<int, Panel>();
+
+
+            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD);
+            //rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.line);
+
+
+            IEnumerable<rfModel.free_line_load> foundFreeLineLoads = numbers.ToList().Select(n => m_Model.get_free_line_load(n.children[0], n.no));
+
+            foreach (rfModel.free_line_load freeLineLoad in foundFreeLineLoads)
+            {
+
+                loads.Add(freeLineLoad.FromRFEM(loadCaseMap[freeLineLoad.load_case], freeLineLoad.surfaces.ToList().Select(s => panelMap[s]).ToList()));
+
+            }
+
+            return loads;
+        }
+
+    
+
         //private List<ILoad> ReadLineLoad(List<string> ids = null)
         //{
         //    //Find all possible Load cases
@@ -167,11 +194,16 @@ namespace BH.Adapter.RFEM6
         //}
 
 
+<<<<<<< HEAD
       
         //    return loads;
         //}
 
         private void UpdateLoadIdDictionary(ILoad load)
+=======
+
+        private void updateLoadIdDictionary(ILoad load)
+>>>>>>> 4a96e76 (...)
         {
 
             if (m_LoadcaseLoadIdDict.TryGetValue(load.Loadcase, out Dictionary<String, int> loadIdDict))

--- a/RFEM6_Adapter/CRUD/Read/_IRead.cs
+++ b/RFEM6_Adapter/CRUD/Read/_IRead.cs
@@ -86,10 +86,13 @@ namespace BH.Adapter.RFEM6
                     return ReadPointLoad(ids as dynamic);
                 else if (type == typeof(AreaUniformlyDistributedLoad))
                     return ReadAreaLoad(ids as dynamic);
+                else if (type == typeof(GeometricalLineLoad))
+                    return ReadLineLoad(ids as dynamic);
                 else if (type == typeof(ILoad)) {
                     List<ILoad> loadList = new List<ILoad>();
                     loadList.AddRange(ReadPointLoad(ids as dynamic));
                     loadList.AddRange(ReadBarLoad(ids as dynamic));
+                    loadList.AddRange(ReadLineLoad(ids as dynamic));
                     return loadList;
                         }
                 //else if (type == typeof(GeometricalLineLoad))

--- a/RFEM6_Adapter/CRUD/Read/_IRead.cs
+++ b/RFEM6_Adapter/CRUD/Read/_IRead.cs
@@ -93,6 +93,7 @@ namespace BH.Adapter.RFEM6
                     loadList.AddRange(ReadPointLoad(ids as dynamic));
                     loadList.AddRange(ReadBarLoad(ids as dynamic));
                     loadList.AddRange(ReadLineLoad(ids as dynamic));
+                    loadList.AddRange(ReadAreaLoad(ids as dynamic));
                     return loadList;
                         }
                 //else if (type == typeof(GeometricalLineLoad))

--- a/RFEM6_Adapter/CRUD/Read/_IRead.cs
+++ b/RFEM6_Adapter/CRUD/Read/_IRead.cs
@@ -84,6 +84,8 @@ namespace BH.Adapter.RFEM6
                     return ReadBarLoad(ids as dynamic);
                 else if (type == typeof(PointLoad))
                     return ReadPointLoad(ids as dynamic);
+                else if (type == typeof(AreaUniformlyDistributedLoad))
+                    return ReadAreaLoad(ids as dynamic);
                 else if (type == typeof(ILoad)) {
                     List<ILoad> loadList = new List<ILoad>();
                     loadList.AddRange(ReadPointLoad(ids as dynamic));
@@ -91,9 +93,7 @@ namespace BH.Adapter.RFEM6
                     return loadList;
                         }
                 //else if (type == typeof(GeometricalLineLoad))
-                //    return ReadLineLoad(ids as dynamic);
-                //else if (type == typeof(AreaUniformlyDistributedLoad))
-                //    return ReadAreaLoad(ids as dynamic);
+                //return ReadLineLoad(ids as dynamic);
             }
             finally
             {

--- a/RFEM6_Adapter/CRUD/Read/_IRead.cs
+++ b/RFEM6_Adapter/CRUD/Read/_IRead.cs
@@ -100,6 +100,7 @@ namespace BH.Adapter.RFEM6
                     loadList.AddRange(ReadPointLoad(ids as dynamic));
                     loadList.AddRange(ReadBarLoad(ids as dynamic));
                     loadList.AddRange(ReadFreeLineLoad(ids as dynamic));
+                    loadList.AddRange(ReadLineLoad(ids as dynamic));
                     loadList.AddRange(ReadAreaLoad(ids as dynamic));
                     return loadList;
                 }

--- a/RFEM6_Adapter/CRUD/Read/_IRead.cs
+++ b/RFEM6_Adapter/CRUD/Read/_IRead.cs
@@ -49,7 +49,7 @@ namespace BH.Adapter.RFEM6
         // It gets called once per each Type.
         protected override IEnumerable<IBHoMObject> IRead(Type type, IList ids, ActionConfig actionConfig = null)
         {
-            
+
             try
             {
                 if (type == typeof(Node))
@@ -87,15 +87,22 @@ namespace BH.Adapter.RFEM6
                 else if (type == typeof(AreaUniformlyDistributedLoad))
                     return ReadAreaLoad(ids as dynamic);
                 else if (type == typeof(GeometricalLineLoad))
-                    return ReadLineLoad(ids as dynamic);
-                else if (type == typeof(ILoad)) {
+                {
+                    List<ILoad> loadList = new List<ILoad>();
+                    loadList.AddRange(ReadFreeLineLoad(ids as dynamic));
+                    loadList.AddRange(ReadLineLoad(ids as dynamic));
+
+                    return loadList;
+                }
+                else if (type == typeof(ILoad))
+                {
                     List<ILoad> loadList = new List<ILoad>();
                     loadList.AddRange(ReadPointLoad(ids as dynamic));
                     loadList.AddRange(ReadBarLoad(ids as dynamic));
-                    loadList.AddRange(ReadLineLoad(ids as dynamic));
+                    loadList.AddRange(ReadFreeLineLoad(ids as dynamic));
                     loadList.AddRange(ReadAreaLoad(ids as dynamic));
                     return loadList;
-                        }
+                }
                 //else if (type == typeof(GeometricalLineLoad))
                 //return ReadLineLoad(ids as dynamic);
             }

--- a/RFEM6_Adapter/Comparers/RFEMLoadComparer.cs
+++ b/RFEM6_Adapter/Comparers/RFEMLoadComparer.cs
@@ -51,11 +51,11 @@ namespace BH.Adapter.RFEM6
 
         public bool Equals(ILoad load0, ILoad load1)
         {
+            //return false;
 
+            if (load0.GetHashCode().Equals(load1.GetHashCode())) return true;
 
-            if(load0.GetHashCode().Equals(load1.GetHashCode())) return true;
-
-                LoadCaseComparer loadCaseComparer = new LoadCaseComparer();
+            LoadCaseComparer loadCaseComparer = new LoadCaseComparer();
             if (!loadCaseComparer.Equals(load0.Loadcase, load1.Loadcase)) return false;
 
             if (load0.Axis != load1.Axis) return false;
@@ -64,14 +64,15 @@ namespace BH.Adapter.RFEM6
 
             if (!load0.GetType().Equals(load1.GetType())) return false;
 
-            if (load0 is GeometricalLineLoad) { 
-            
+            if (load0 is GeometricalLineLoad)
+            {
+
                 Line line0 = ((GeometricalLineLoad)load0).Location;
                 Line line1 = ((GeometricalLineLoad)load1).Location;
 
                 NodeDistanceComparer comparer = new NodeDistanceComparer(3);
-                
-                if(!comparer.Equals(new Node() {Position= line0.Start }, new Node() { Position = line1.Start })) return false;
+
+                if (!comparer.Equals(new Node() { Position = line0.Start }, new Node() { Position = line1.Start })) return false;
 
                 if (!comparer.Equals(new Node() { Position = line0.End }, new Node() { Position = line1.End })) return false;
 
@@ -83,12 +84,24 @@ namespace BH.Adapter.RFEM6
                 //Line line0 = ((PointLoad)load0).;
                 //Line line1 = ((PointLoad)load1).;
             }
-            if (load0 is BarUniformlyDistributedLoad) { 
+            if (load0 is BarUniformlyDistributedLoad)
+            {
 
                 //((BarUniformlyDistributedLoad)load0).
 
             }
-            
+            if (load0 is AreaUniformlyDistributedLoad)
+            {
+
+                if ((load0 as AreaUniformlyDistributedLoad).Pressure.X != (load1 as AreaUniformlyDistributedLoad).Pressure.X) return false;
+                if ((load0 as AreaUniformlyDistributedLoad).Pressure.Y != (load1 as AreaUniformlyDistributedLoad).Pressure.Y) return false;
+                if ((load0 as AreaUniformlyDistributedLoad).Pressure.Z != (load1 as AreaUniformlyDistributedLoad).Pressure.Z) return false;
+
+
+
+
+            }
+
 
 
             return true;
@@ -103,7 +116,7 @@ namespace BH.Adapter.RFEM6
             //return surfaceSupport.GetHashCode();
 
             return 0;
-            
+
         }
 
 

--- a/RFEM6_Adapter/Comparers/RFEMPanelComparer.cs
+++ b/RFEM6_Adapter/Comparers/RFEMPanelComparer.cs
@@ -56,7 +56,7 @@ namespace BH.Adapter.RFEM6
 
         public bool Equals(Panel panel1, Panel panel2)
         {
-
+            //return false;
             bool equal = false;
 
             var lst1 = panel1.ExternalEdges.Select(e => (e.Curve)).ToList();

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -167,23 +167,25 @@ namespace BH.Adapter.RFEM6
         {
             Vector impactA = new Vector();
             Vector impactB = new Vector();
+            double impactMagnitudeA = rfLineload.load_distribution == line_load_load_distribution.LOAD_DISTRIBUTION_TRAPEZOIDAL ? rfLineload.magnitude_1 : rfLineload.magnitude;
+            double impactMagnitudeB = rfLineload.load_distribution == line_load_load_distribution.LOAD_DISTRIBUTION_TRAPEZOIDAL ? rfLineload.magnitude_2 : rfLineload.magnitude;
 
             if (rfLineload.load_direction == line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE)
             {
 
-                impactA.X = rfLineload.magnitude_1;
-                impactB.X = rfLineload.magnitude_2;
+                impactA.X = impactMagnitudeA;
+                impactB.X = impactMagnitudeB;
 
             }
             else if (rfLineload.load_direction == line_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE)
             {
-                impactA.Y = rfLineload.magnitude_1;
-                impactB.Y = rfLineload.magnitude_2;
+                impactA.Y = impactMagnitudeA;
+                impactB.Y = impactMagnitudeB;
             }
             else if (rfLineload.load_direction == line_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE)
             {
-                impactA.Z = rfLineload.magnitude_1;
-                impactB.Z = rfLineload.magnitude_2;
+                impactA.Z = impactMagnitudeA;
+                impactB.Z = impactMagnitudeB;
             }
             else
             {

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -112,6 +112,35 @@ namespace BH.Adapter.RFEM6
             return bhLoad;
         }
 
+        public static AreaUniformlyDistributedLoad FromRFEM(this rfModel.surface_load surfaceload, Loadcase loadcase, List<Panel> panels)
+        {
+
+            Vector forceDirection;
+
+            if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE)
+            {
+                forceDirection = BH.Engine.Geometry.Create.Vector(surfaceload.uniform_magnitude, 0, 0);
+            }
+            else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE)
+            {
+                forceDirection = BH.Engine.Geometry.Create.Vector(0, surfaceload.uniform_magnitude, 0);
+            }
+            else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE)
+            {
+                forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+            }
+            else
+            {
+                forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+            }
+
+            AreaUniformlyDistributedLoad bhAreaload = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcase, forceDirection, panels);
+
+            return bhAreaload;
+        }
+
+
+
         //public static GeometricalLineLoad FromRFEM(this rfModel.line_load lineLoad, Loadcase bhLoadCase, Edge edge)
         //{
         //    bool isProjected = false;
@@ -165,13 +194,6 @@ namespace BH.Adapter.RFEM6
         //}
 
 
-        //public static AreaUniformlyDistributedLoad FromRFEM(this rfModel.surface_load surfaceload, Loadcase loadcase, List<Panel> panels)
-        //{
-
-        //    AreaUniformlyDistributedLoad bhAreaload=BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcase, Vector.ZAxis, panels);
-
-        //    return bhAreaload;
-        //}
 
 
     }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -139,6 +139,7 @@ namespace BH.Adapter.RFEM6
             return bhAreaload;
         }
 
+        // convert Free Line Loads into Geometrical Line Loads
         public static GeometricalLineLoad FromRFEM(this rfModel.free_line_load rfLineload, Loadcase loadcase, List<Panel> panels)
         {
 
@@ -147,6 +148,7 @@ namespace BH.Adapter.RFEM6
 
             GeometricalLineLoad bhLineLoad = new GeometricalLineLoad()
             {
+                Name="Free",
                 Loadcase = loadcase,
                 Location = line,
                 ForceA = BH.Engine.Geometry.Create.Vector(0, 0, rfLineload.magnitude_secondSpecified ? rfLineload.magnitude_first : rfLineload.magnitude_uniform),
@@ -156,6 +158,51 @@ namespace BH.Adapter.RFEM6
 
             //GeometricalLineLoad bhLineLoad = BH.Engine.Structure.Create.GeometricalLineLoad(line, loadcase, Vector.ZAxis, Vector.ZAxis, panels);
 
+
+            return bhLineLoad;
+        }
+
+        // convert  Line Loads into Geometrical Line Loads
+        public static GeometricalLineLoad FromRFEM(this rfModel.line_load rfLineload, Loadcase loadcase, Line line)
+        {
+            Vector impactA = new Vector();
+            Vector impactB = new Vector();
+
+            if (rfLineload.load_direction == line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE)
+            {
+
+                impactA.X = rfLineload.magnitude_1;
+                impactB.X = rfLineload.magnitude_2;
+
+            }
+            else if (rfLineload.load_direction == line_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE)
+            {
+                impactA.Y = rfLineload.magnitude_1;
+                impactB.Y = rfLineload.magnitude_2;
+            }
+            else if (rfLineload.load_direction == line_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE)
+            {
+                impactA.Z = rfLineload.magnitude_1;
+                impactB.Z = rfLineload.magnitude_2;
+            }
+            else
+            {
+                BH.Engine.Base.Compute.RecordError($"The Load {rfLineload} within RFEM6 is has not direction that is Parallel to the X,Y or Z axist. The Load direction will be set to a null-vector!");
+
+
+            }
+
+            GeometricalLineLoad bhLineLoad = new GeometricalLineLoad()
+            {
+                Name="NonFree",
+                Loadcase = loadcase,
+                Location = line,
+                ForceA = rfLineload.load_type == rfModel.line_load_load_type.LOAD_TYPE_FORCE ? impactA : new Vector(),
+                ForceB = rfLineload.load_type == rfModel.line_load_load_type.LOAD_TYPE_FORCE ? impactB : new Vector(),
+                MomentA = rfLineload.load_type == rfModel.line_load_load_type.LOAD_TYPE_MOMENT ? impactA : new Vector(),
+                MomentB = rfLineload.load_type == rfModel.line_load_load_type.LOAD_TYPE_MOMENT ? impactB : new Vector(),
+
+            };
 
             return bhLineLoad;
         }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -139,7 +139,21 @@ namespace BH.Adapter.RFEM6
             return bhAreaload;
         }
 
+        public static GeometricalLineLoad FromRFEM(this rfModel.free_line_load rfLineload, Loadcase loadcase, List<Panel> panels)
+        {
 
+
+            
+            //Point p = new Point() { X=rfLineload.load_location_first_x,Y=rfLineload.load_location_first_y,Z=rfLineload.load_location_z };
+            
+
+            Line line = new BH.oM.Geometry.Line() { Start = new Point() { X = rfLineload.load_location_first_x, Y = rfLineload.load_location_first_y, Z = 0 }, End = new Point() { X = rfLineload.load_location_second_x, Y = rfLineload.load_location_second_y, Z = 0 } };
+
+            GeometricalLineLoad bhLineLoad = BH.Engine.Structure.Create.GeometricalLineLoad(line, loadcase, Vector.ZAxis, Vector.ZAxis, panels);
+
+
+            return bhLineLoad;
+        }
 
         //public static GeometricalLineLoad FromRFEM(this rfModel.line_load lineLoad, Loadcase bhLoadCase, Edge edge)
         //{

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -53,8 +53,8 @@ namespace BH.Adapter.RFEM6
             }
             else if (rfMemberLoad.load_direction == member_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED || rfMemberLoad.load_direction == member_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE || rfMemberLoad.load_direction == member_load_load_direction.LOAD_DIRECTION_LOCAL_Y)
             {
-                momentVector = rfMemberLoad.load_type == member_load_load_type.LOAD_TYPE_MOMENT ? -1*(new Vector() { X = 0, Y = rfMemberLoad.magnitude, Z = 0 }) : new Vector() { X = 0, Y = 0, Z = 0 };
-                forceVector = rfMemberLoad.load_type == member_load_load_type.LOAD_TYPE_FORCE ? -1*(new Vector() { X = 0, Y = rfMemberLoad.magnitude, Z = 0 }) : new Vector() { X = 0, Y = 0, Z = 0 };
+                momentVector = rfMemberLoad.load_type == member_load_load_type.LOAD_TYPE_MOMENT ? -1 * (new Vector() { X = 0, Y = rfMemberLoad.magnitude, Z = 0 }) : new Vector() { X = 0, Y = 0, Z = 0 };
+                forceVector = rfMemberLoad.load_type == member_load_load_type.LOAD_TYPE_FORCE ? -1 * (new Vector() { X = 0, Y = rfMemberLoad.magnitude, Z = 0 }) : new Vector() { X = 0, Y = 0, Z = 0 };
             }
             else
             {
@@ -143,13 +143,18 @@ namespace BH.Adapter.RFEM6
         {
 
 
-            
-            //Point p = new Point() { X=rfLineload.load_location_first_x,Y=rfLineload.load_location_first_y,Z=rfLineload.load_location_z };
-            
-
             Line line = new BH.oM.Geometry.Line() { Start = new Point() { X = rfLineload.load_location_first_x, Y = rfLineload.load_location_first_y, Z = 0 }, End = new Point() { X = rfLineload.load_location_second_x, Y = rfLineload.load_location_second_y, Z = 0 } };
 
-            GeometricalLineLoad bhLineLoad = BH.Engine.Structure.Create.GeometricalLineLoad(line, loadcase, Vector.ZAxis, Vector.ZAxis, panels);
+            GeometricalLineLoad bhLineLoad = new GeometricalLineLoad()
+            {
+                Loadcase = loadcase,
+                Location = line,
+                ForceA = BH.Engine.Geometry.Create.Vector(0, 0, rfLineload.magnitude_secondSpecified ? rfLineload.magnitude_first : rfLineload.magnitude_uniform),
+                ForceB = BH.Engine.Geometry.Create.Vector(0, 0, rfLineload.magnitude_secondSpecified ? rfLineload.magnitude_second : rfLineload.magnitude_uniform),
+
+            };
+
+            //GeometricalLineLoad bhLineLoad = BH.Engine.Structure.Create.GeometricalLineLoad(line, loadcase, Vector.ZAxis, Vector.ZAxis, panels);
 
 
             return bhLineLoad;

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -34,6 +34,8 @@ using BH.oM.Structure.Loads;
 using BH.oM.Geometry;
 using BH.Engine.Spatial;
 using Dlubal.WS.Rfem6.Model;
+using BH.oM.Adapters.RFEM6.BHoMDataStructure.SupportDatastrures;
+using BH.oM.Adapters.RFEM6.Fragments.Enums;
 
 namespace BH.Adapter.RFEM6
 {
@@ -64,10 +66,12 @@ namespace BH.Adapter.RFEM6
 
             BarUniformlyDistributedLoad bhLoad = new BarUniformlyDistributedLoad
             {
+                Name=rfMemberLoad.comment,
                 Objects = new BH.oM.Base.BHoMGroup<Bar>() { Elements = bhBars },
                 Loadcase = bhLoadCase,
                 Force = forceVector,
                 Moment = momentVector
+                
             };
 
             return bhLoad;
@@ -106,6 +110,7 @@ namespace BH.Adapter.RFEM6
                 Loadcase = bhLoadCase,
                 Force = BH.Engine.Geometry.Create.Vector(force[0], force[1], force[2]),
                 Moment = BH.Engine.Geometry.Create.Vector(moment[0], moment[1], moment[2]),
+                Name= nodeLoad.comment
             };
 
 
@@ -116,25 +121,77 @@ namespace BH.Adapter.RFEM6
         {
 
             Vector forceDirection;
+            bool isProjected = false;
 
-            if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE)
+
+            //if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE)
+            //{
+            //    forceDirection = BH.Engine.Geometry.Create.Vector(surfaceload.uniform_magnitude, 0, 0);
+            //}
+            //else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE)
+            //{
+            //    forceDirection = BH.Engine.Geometry.Create.Vector(0, surfaceload.uniform_magnitude, 0);
+            //}
+            //else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE)
+            //{
+            //    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+            //}
+            //else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED)
+            //{
+            //    forceDirection = BH.Engine.Geometry.Create.Vector(surfaceload.uniform_magnitude, 0, 0);
+            //    isProjected = true;
+            //}
+            //else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED)
+            //{
+            //    forceDirection = BH.Engine.Geometry.Create.Vector(0, surfaceload.uniform_magnitude, 0);
+            //    isProjected = true;
+            //}
+            //else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_PROJECTED)
+            //{
+            //    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+            //    isProjected = true;
+            //}
+            //else
+            //{
+            //    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+            //}
+
+            switch (surfaceload.load_direction)
             {
-                forceDirection = BH.Engine.Geometry.Create.Vector(surfaceload.uniform_magnitude, 0, 0);
-            }
-            else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE)
-            {
-                forceDirection = BH.Engine.Geometry.Create.Vector(0, surfaceload.uniform_magnitude, 0);
-            }
-            else if (surfaceload.load_direction == surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE)
-            {
-                forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
-            }
-            else
-            {
-                forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+                case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(surfaceload.uniform_magnitude, 0, 0);
+                    break;
+
+                case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, surfaceload.uniform_magnitude, 0);
+                    break;
+
+                case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+                    break;
+
+                case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(surfaceload.uniform_magnitude, 0, 0);
+                    isProjected = true;
+                    break;
+
+                case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, surfaceload.uniform_magnitude, 0);
+                    isProjected = true;
+                    break;
+
+                case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_PROJECTED:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+                    isProjected = true;
+                    break;
+
+                default:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, surfaceload.uniform_magnitude);
+                    break;
             }
 
-            AreaUniformlyDistributedLoad bhAreaload = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcase, forceDirection, panels);
+
+            AreaUniformlyDistributedLoad bhAreaload = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcase, forceDirection, panels,LoadAxis.Global,isProjected,surfaceload.comment);
 
             return bhAreaload;
         }
@@ -148,7 +205,7 @@ namespace BH.Adapter.RFEM6
 
             GeometricalLineLoad bhLineLoad = new GeometricalLineLoad()
             {
-                Name="Free",
+                Name=rfLineload.comment,
                 Loadcase = loadcase,
                 Location = line,
                 ForceA = BH.Engine.Geometry.Create.Vector(0, 0, rfLineload.magnitude_secondSpecified ? rfLineload.magnitude_first : rfLineload.magnitude_uniform),
@@ -156,6 +213,7 @@ namespace BH.Adapter.RFEM6
 
             };
 
+            bhLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.AddFragment(bhLineLoad, (new RFEM6GeometricalLineLoadTypes() { geometrialLineLoadType = GeometricalLineLoadTypesEnum.FreeLineLoad }));
             //GeometricalLineLoad bhLineLoad = BH.Engine.Structure.Create.GeometricalLineLoad(line, loadcase, Vector.ZAxis, Vector.ZAxis, panels);
 
 
@@ -196,7 +254,7 @@ namespace BH.Adapter.RFEM6
 
             GeometricalLineLoad bhLineLoad = new GeometricalLineLoad()
             {
-                Name="NonFree",
+                Name=rfLineload.comment,
                 Loadcase = loadcase,
                 Location = line,
                 ForceA = rfLineload.load_type == rfModel.line_load_load_type.LOAD_TYPE_FORCE ? impactA : new Vector(),
@@ -206,63 +264,12 @@ namespace BH.Adapter.RFEM6
 
             };
 
+            bhLineLoad = (GeometricalLineLoad)BH.Engine.Base.Modify.AddFragment(bhLineLoad, (new RFEM6GeometricalLineLoadTypes() { geometrialLineLoadType = GeometricalLineLoadTypesEnum.NonFreeLineLoad }));
+
             return bhLineLoad;
         }
 
-        //public static GeometricalLineLoad FromRFEM(this rfModel.line_load lineLoad, Loadcase bhLoadCase, Edge edge)
-        //{
-        //    bool isProjected = false;
-        //    Vector startImpact = new Vector() { X = 0, Y = 0, Z = lineLoad.magnitude };
-        //    Vector endImpact = new Vector() { X = 0, Y = 0, Z = lineLoad.magnitude };
-        //    Line line = new Line() { Start = edge.Curve.ControlPoints().ToList().First(), End = edge.Curve.ControlPoints().ToList().Last() };
-
-        //    switch (lineLoad.load_direction)
-        //    {
-        //        case line_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE:
-        //            isProjected = false;
-        //            startImpact = new Vector() { X = 0, Y = 0, Z = lineLoad.magnitude };
-        //            endImpact = new Vector() { X = 0, Y = 0, Z = lineLoad.magnitude };
-        //            break;
-        //        case line_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_PROJECTED:
-        //            isProjected = true;
-        //            startImpact = new Vector() { X = 0, Y = 0, Z = lineLoad.magnitude };
-        //            endImpact = new Vector() { X = 0, Y = 0, Z = lineLoad.magnitude };
-        //            break;
-        //        case line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE:
-        //            isProjected = false;
-        //            startImpact = new Vector() { X = lineLoad.magnitude, Y = 0, Z = 0 };
-        //            endImpact = new Vector() { X = lineLoad.magnitude, Y = 0, Z = 0 };
-        //            break;
-        //        case line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED:
-        //            isProjected = true;
-        //            startImpact = new Vector() { X = lineLoad.magnitude, Y = 0, Z = 0 };
-        //            endImpact = new Vector() { X = lineLoad.magnitude, Y = 0, Z = 0 };
-        //            break;
-        //        case line_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE:
-        //            isProjected = false;
-        //            startImpact = new Vector() { X = 0, Y = lineLoad.magnitude, Z = 0 };
-        //            endImpact = new Vector() { X = 0, Y = lineLoad.magnitude, Z = 0 };
-        //            break;
-        //        case line_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED:
-        //            isProjected = true;
-        //            startImpact = new Vector() { X = lineLoad.magnitude, Y = 0, Z = 0 };
-        //            endImpact = new Vector() { X = lineLoad.magnitude, Y = 0, Z = 0 };
-        //            break;
-        //        default:
-        //            isProjected = false;
-        //            startImpact = new Vector() { X = 0, Y = 0, Z = lineLoad.magnitude };
-        //            endImpact = new Vector() { X = 0, Y = 0, Z = lineLoad.magnitude };
-        //            break;
-        //    }
-
-        //    GeometricalLineLoad bhLoad = (lineLoad.load_type == line_load_load_type.LOAD_TYPE_FORCE) ? BH.Engine.Structure.Create.GeometricalLineLoad(line, bhLoadCase, startImpact, endImpact, new Vector(), new Vector()) : BH.Engine.Structure.Create.GeometricalLineLoad(line, bhLoadCase, new Vector(), new Vector(), startImpact, endImpact);
-        //    bhLoad.Projected = isProjected;
-
-        //    return bhLoad;
-        //}
-
-
-
+        
 
     }
 }

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -175,6 +175,46 @@ namespace BH.Adapter.RFEM6
         }
 
 
+        public static rfModel.free_line_load ToRFEM6(this GeometricalLineLoad bhLineLoad, int loadCaseSpecificID, int[] surfaceIds)
+        {
+
+
+
+            free_line_load rfLineLoad = new rfModel.free_line_load()
+            {
+                surfaces = surfaceIds,
+                surfaces_string = string.Join(" ", surfaceIds.Select(n => n.ToString())),
+                
+                no = loadCaseSpecificID,
+                load_case = bhLineLoad.Loadcase.GetRFEM6ID(),
+                load_caseSpecified = true,
+                load_distribution = free_line_load_load_distribution.LOAD_DISTRIBUTION_LINEAR,
+                load_distributionSpecified = true,
+                magnitude_first = bhLineLoad.ForceA.Length(),
+                magnitude_firstSpecified = true,
+                magnitude_second = bhLineLoad.ForceB.Length(),
+                magnitude_secondSpecified = true,
+                is_generated = false,
+                is_generatedSpecified = true,
+                load_direction = bhLineLoad.Projected ? free_line_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_PROJECTED : free_line_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_TRUE,
+                load_directionSpecified = true,
+                load_location_first_x = bhLineLoad.Location.Start.X,
+                load_location_first_xSpecified = true,
+                load_location_first_y = bhLineLoad.Location.Start.Y,
+                load_location_first_ySpecified = true,
+                load_location_second_x = bhLineLoad.Location.End.X,
+                load_location_second_xSpecified = true,
+                load_location_second_y = bhLineLoad.Location.End.Y,
+                load_location_second_ySpecified = true,
+                
+              
+            };
+
+
+            return rfLineLoad;
+
+        }
+
         //public static rfModel.line_load ToRFEM6(this GeometricalLineLoad bhLineLoad, List<int> lineNoList)
         //{
 
@@ -182,22 +222,22 @@ namespace BH.Adapter.RFEM6
         //    {
         //        no = bhLineLoad.GetRFEM6ID(),
         //        lines = lineNoList.ToArray(),
-        //        load_case=bhLineLoad.Loadcase.GetRFEM6ID(),
-        //        load_caseSpecified=true,
+        //        load_case = bhLineLoad.Loadcase.GetRFEM6ID(),
+        //        load_caseSpecified = true,
         //        load_distribution = line_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
         //        load_distributionSpecified = true,
         //        magnitude = bhLineLoad.ForceA.Length(),
         //        magnitudeSpecified = true,
-        //        reference_to_list_of_lines=false,
-        //        reference_to_list_of_linesSpecified=true,
-        //        is_generated=false,
-        //        is_generatedSpecified=true,
+        //        reference_to_list_of_lines = false,
+        //        reference_to_list_of_linesSpecified = true,
+        //        is_generated = false,
+        //        is_generatedSpecified = true,
         //        load_direction = line_load_load_direction.LOAD_DIRECTION_LOCAL_Z,
         //        load_directionSpecified = true,
         //        load_is_over_total_length = true,
         //        load_is_over_total_lengthSpecified = true,
-        //        load_type= line_load_load_type.LOAD_TYPE_FORCE,
-        //        load_typeSpecified=true,
+        //        load_type = line_load_load_type.LOAD_TYPE_FORCE,
+        //        load_typeSpecified = true,
         //    };
 
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -53,13 +53,13 @@ namespace BH.Adapter.RFEM6
 
             if (orientationVector.X != 0)
             {
-                loadDirecteion = bhBarLoad.Projected? member_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED : member_load_load_direction.LOAD_DIRECTION_LOCAL_X;
+                loadDirecteion = bhBarLoad.Projected ? member_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED : member_load_load_direction.LOAD_DIRECTION_LOCAL_X;
                 loadMagintude = nodalLoadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.Length() : bhBarLoad.Moment.Length();
             }
             else if (orientationVector.Y != 0)
             {
                 loadDirecteion = bhBarLoad.Projected ? member_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED : member_load_load_direction.LOAD_DIRECTION_LOCAL_Y;
-                loadMagintude = nodalLoadType == member_load_load_type.LOAD_TYPE_FORCE ? -1*bhBarLoad.Force.Length() : -1*bhBarLoad.Moment.Length();
+                loadMagintude = nodalLoadType == member_load_load_type.LOAD_TYPE_FORCE ? -1 * bhBarLoad.Force.Length() : -1 * bhBarLoad.Moment.Length();
 
             }
             else
@@ -134,17 +134,21 @@ namespace BH.Adapter.RFEM6
         public static rfModel.surface_load ToRFEM6(this AreaUniformlyDistributedLoad bhAreaLoad, int loadCaseSpecificLoadId)
         {
 
-            
+
 
 
             surface_load_load_direction loadDirecteion;
             Vector orientationVector = bhAreaLoad.Pressure;
-            if (orientationVector.X != 0) { 
-                loadDirecteion = bhAreaLoad.Projected?surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED: surface_load_load_direction.LOAD_DIRECTION_LOCAL_X; }
-            else if (orientationVector.Y != 0) {
+            if (orientationVector.X != 0)
+            {
+                loadDirecteion = bhAreaLoad.Projected ? surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED : surface_load_load_direction.LOAD_DIRECTION_LOCAL_X;
+            }
+            else if (orientationVector.Y != 0)
+            {
                 loadDirecteion = bhAreaLoad.Projected ? surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED : surface_load_load_direction.LOAD_DIRECTION_LOCAL_Y;
             }
-            else {
+            else
+            {
                 loadDirecteion = bhAreaLoad.Projected ? surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_PROJECTED : surface_load_load_direction.LOAD_DIRECTION_LOCAL_Z;
             }
 
@@ -184,7 +188,7 @@ namespace BH.Adapter.RFEM6
             {
                 surfaces = surfaceIds,
                 surfaces_string = string.Join(" ", surfaceIds.Select(n => n.ToString())),
-                
+
                 no = loadCaseSpecificID,
                 load_case = bhLineLoad.Loadcase.GetRFEM6ID(),
                 load_caseSpecified = true,
@@ -206,8 +210,8 @@ namespace BH.Adapter.RFEM6
                 load_location_second_xSpecified = true,
                 load_location_second_y = bhLineLoad.Location.End.Y,
                 load_location_second_ySpecified = true,
-                
-              
+
+
             };
 
 
@@ -215,29 +219,82 @@ namespace BH.Adapter.RFEM6
 
         }
 
-        public static rfModel.line_load ToRFEM6(this GeometricalLineLoad bhLineLoad, int id, int foundEdgeId)
+        public static rfModel.line_load ToRFEM6(this GeometricalLineLoad bhLineLoad, int id, int foundEdgeId, line_load_load_type rfLineLoadType)
         {
+
+
+            //Checking for diretction of the GeometricalLineLoad. First discitguishing by Moment or force. 
+            //Additionally setting both Maginigutes.
+            line_load_load_direction rfLineLoadDirection;
+            double loadMagnitude1;
+            double loadMagnitude2;
+            if (rfLineLoadType.Equals(rfModel.line_load_load_type.LOAD_TYPE_MOMENT))
+            {
+                if (bhLineLoad.MomentA.X != 0||bhLineLoad.MomentB.X!=0)
+                {
+                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE;
+                    loadMagnitude1 = bhLineLoad.MomentA.X;
+                    loadMagnitude2 = bhLineLoad.MomentB.X;
+                }
+                else if (bhLineLoad.MomentA.Y != 0 || bhLineLoad.MomentB.Y != 0)
+                {
+                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE;
+                    loadMagnitude1 = bhLineLoad.MomentA.Y;
+                    loadMagnitude2 = bhLineLoad.MomentB.Y;
+                }
+                else
+                {
+                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE;
+                    loadMagnitude1 = bhLineLoad.MomentA.Z;
+                    loadMagnitude2 = bhLineLoad.MomentB.Z;
+                }
+            }
+            else
+            {
+                if (bhLineLoad.ForceA.X != 0|| bhLineLoad.ForceB.X != 0)
+                {
+                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE;
+                    loadMagnitude1 = bhLineLoad.ForceA.X;
+                    loadMagnitude2 = bhLineLoad.ForceB.X;
+                }
+                else if (bhLineLoad.ForceA.Y != 0 || bhLineLoad.ForceB.Y != 0)
+                {
+                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE;
+                    loadMagnitude1 = bhLineLoad.ForceA.Y;
+                    loadMagnitude2 = bhLineLoad.ForceB.Y;
+                }
+                else
+                {
+                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE;
+                    loadMagnitude1 = bhLineLoad.ForceA.Z;
+                    loadMagnitude2 = bhLineLoad.ForceB.Z;
+                }
+
+            }
 
             line_load rfLineLoad = new rfModel.line_load()
             {
-                //no = bhLineLoad.GetRFEM6ID(),
                 no = id,
                 lines = new int[] { foundEdgeId },
                 load_case = bhLineLoad.Loadcase.GetRFEM6ID(),
                 load_caseSpecified = true,
-                load_distribution = line_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
+                load_distribution = line_load_load_distribution.LOAD_DISTRIBUTION_TRAPEZOIDAL,
                 load_distributionSpecified = true,
                 magnitude = bhLineLoad.ForceA.Length(),
                 magnitudeSpecified = true,
+                magnitude_1 = loadMagnitude1,
+                magnitude_1Specified = true,
+                magnitude_2 = loadMagnitude2,
+                magnitude_2Specified = true,
                 reference_to_list_of_lines = false,
                 reference_to_list_of_linesSpecified = true,
                 is_generated = false,
                 is_generatedSpecified = true,
-                load_direction = line_load_load_direction.LOAD_DIRECTION_LOCAL_Z,
+                load_direction = rfLineLoadDirection,
                 load_directionSpecified = true,
                 load_is_over_total_length = true,
                 load_is_over_total_lengthSpecified = true,
-                load_type = line_load_load_type.LOAD_TYPE_FORCE,
+                load_type = rfLineLoadType,
                 load_typeSpecified = true,
             };
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -244,7 +244,7 @@ namespace BH.Adapter.RFEM6
                 }
                 else
                 {
-                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE;
+                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE;
                     loadMagnitude1 = bhLineLoad.MomentA.Z;
                     loadMagnitude2 = bhLineLoad.MomentB.Z;
                 }
@@ -265,7 +265,7 @@ namespace BH.Adapter.RFEM6
                 }
                 else
                 {
-                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE;
+                    rfLineLoadDirection = line_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE;
                     loadMagnitude1 = bhLineLoad.ForceA.Z;
                     loadMagnitude2 = bhLineLoad.ForceB.Z;
                 }

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -131,6 +131,45 @@ namespace BH.Adapter.RFEM6
 
         }
 
+        public static rfModel.surface_load ToRFEM6(this AreaUniformlyDistributedLoad bhAreaLoad, int loadCaseSpecificLoadId)
+        {
+
+            
+
+
+            surface_load_load_direction loadDirecteion;
+            Vector orientationVector = bhAreaLoad.Pressure;
+            if (orientationVector.X != 0) { loadDirecteion = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE; }
+            else if (orientationVector.Y != 0) { loadDirecteion = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE; }
+            else { loadDirecteion = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE; }
+
+
+            surface_load rfSurfaceLoad = new rfModel.surface_load()
+            {
+                no = loadCaseSpecificLoadId,
+                surfaces = bhAreaLoad.Objects.Elements.ToList().Select(x => (x as Panel).GetRFEM6ID()).ToArray(),
+                load_case = bhAreaLoad.Loadcase.GetRFEM6ID(),
+                load_caseSpecified = true,
+                load_distribution = surface_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
+                load_distributionSpecified = true,
+                magnitude_force_u = bhAreaLoad.Pressure.Length(),
+                magnitude_force_uSpecified = true,
+                uniform_magnitude = bhAreaLoad.Pressure.Length(),
+                uniform_magnitudeSpecified = true,
+                is_generated = false,
+                is_generatedSpecified = true,
+                load_direction = loadDirecteion,
+                load_directionSpecified = true,
+                load_type = surface_load_load_type.LOAD_TYPE_FORCE,
+                load_typeSpecified = true,
+            };
+
+
+            return rfSurfaceLoad;
+
+        }
+
+
         //public static rfModel.line_load ToRFEM6(this GeometricalLineLoad bhLineLoad, List<int> lineNoList)
         //{
 
@@ -161,34 +200,6 @@ namespace BH.Adapter.RFEM6
 
         //}
 
-        //public static rfModel.surface_load ToRFEM6(this AreaUniformlyDistributedLoad bhAreaLoad)
-        //{
-
-        //    surface_load rfSurfaceLoad = new rfModel.surface_load()
-        //    {
-        //        no = bhAreaLoad.GetRFEM6ID(),
-        //        surfaces = bhAreaLoad.Objects.Elements.ToList().Select(x => (x as Panel).GetRFEM6ID()).ToArray(),
-        //        //surfaces = new int[] {1},
-        //        load_case = bhAreaLoad.Loadcase.GetRFEM6ID(),
-        //        load_caseSpecified = true,
-        //        load_distribution = surface_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
-        //        load_distributionSpecified = true,
-        //        magnitude_force_u = bhAreaLoad.Pressure.Length(),
-        //        magnitude_force_uSpecified = true,
-        //        uniform_magnitude = bhAreaLoad.Pressure.Length(),
-        //        uniform_magnitudeSpecified = true,
-        //        is_generated = false,
-        //        is_generatedSpecified = true,
-        //        load_direction = surface_load_load_direction.LOAD_DIRECTION_LOCAL_Z,
-        //        load_directionSpecified = true,
-        //        load_type = surface_load_load_type.LOAD_TYPE_FORCE,
-        //        load_typeSpecified = true,
-        //    };
-
-
-        //    return rfSurfaceLoad;
-
-        //}
 
 
     }

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -215,35 +215,36 @@ namespace BH.Adapter.RFEM6
 
         }
 
-        //public static rfModel.line_load ToRFEM6(this GeometricalLineLoad bhLineLoad, List<int> lineNoList)
-        //{
+        public static rfModel.line_load ToRFEM6(this GeometricalLineLoad bhLineLoad, int id, int foundEdgeId)
+        {
 
-        //    line_load rfLineLoad = new rfModel.line_load()
-        //    {
-        //        no = bhLineLoad.GetRFEM6ID(),
-        //        lines = lineNoList.ToArray(),
-        //        load_case = bhLineLoad.Loadcase.GetRFEM6ID(),
-        //        load_caseSpecified = true,
-        //        load_distribution = line_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
-        //        load_distributionSpecified = true,
-        //        magnitude = bhLineLoad.ForceA.Length(),
-        //        magnitudeSpecified = true,
-        //        reference_to_list_of_lines = false,
-        //        reference_to_list_of_linesSpecified = true,
-        //        is_generated = false,
-        //        is_generatedSpecified = true,
-        //        load_direction = line_load_load_direction.LOAD_DIRECTION_LOCAL_Z,
-        //        load_directionSpecified = true,
-        //        load_is_over_total_length = true,
-        //        load_is_over_total_lengthSpecified = true,
-        //        load_type = line_load_load_type.LOAD_TYPE_FORCE,
-        //        load_typeSpecified = true,
-        //    };
+            line_load rfLineLoad = new rfModel.line_load()
+            {
+                //no = bhLineLoad.GetRFEM6ID(),
+                no = id,
+                lines = new int[] { foundEdgeId },
+                load_case = bhLineLoad.Loadcase.GetRFEM6ID(),
+                load_caseSpecified = true,
+                load_distribution = line_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
+                load_distributionSpecified = true,
+                magnitude = bhLineLoad.ForceA.Length(),
+                magnitudeSpecified = true,
+                reference_to_list_of_lines = false,
+                reference_to_list_of_linesSpecified = true,
+                is_generated = false,
+                is_generatedSpecified = true,
+                load_direction = line_load_load_direction.LOAD_DIRECTION_LOCAL_Z,
+                load_directionSpecified = true,
+                load_is_over_total_length = true,
+                load_is_over_total_lengthSpecified = true,
+                load_type = line_load_load_type.LOAD_TYPE_FORCE,
+                load_typeSpecified = true,
+            };
 
 
-        //    return rfLineLoad;
+            return rfLineLoad;
 
-        //}
+        }
 
 
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -71,6 +71,7 @@ namespace BH.Adapter.RFEM6
             member_load rfLoadCase = new rfModel.member_load()
             {
                 no = id,
+                comment=bhBarLoad.Name,
                 members = bhBarLoad.Objects.Elements.ToList().Select(x => x.GetRFEM6ID()).ToArray(),
                 load_distribution = member_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
                 load_distributionSpecified = true,
@@ -101,7 +102,9 @@ namespace BH.Adapter.RFEM6
 
             nodal_load rfLoadCase = new rfModel.nodal_load()
             {
+
                 no = id,
+                comment=bhPointLoad.Name,
                 nodes = bhPointLoad.Objects.Elements.ToList().Select(x => x.GetRFEM6ID()).ToArray(),
                 //load_direction = loadDirecteion,
                 //load_directionSpecified = true,
@@ -156,6 +159,7 @@ namespace BH.Adapter.RFEM6
             surface_load rfSurfaceLoad = new rfModel.surface_load()
             {
                 no = loadCaseSpecificLoadId,
+                comment=bhAreaLoad.Name,
                 surfaces = bhAreaLoad.Objects.Elements.ToList().Select(x => (x as Panel).GetRFEM6ID()).ToArray(),
                 load_case = bhAreaLoad.Loadcase.GetRFEM6ID(),
                 load_caseSpecified = true,
@@ -210,7 +214,7 @@ namespace BH.Adapter.RFEM6
                 load_location_second_xSpecified = true,
                 load_location_second_y = bhLineLoad.Location.End.Y,
                 load_location_second_ySpecified = true,
-
+                comment= bhLineLoad.Name,
 
             };
 
@@ -296,6 +300,8 @@ namespace BH.Adapter.RFEM6
                 load_is_over_total_lengthSpecified = true,
                 load_type = rfLineLoadType,
                 load_typeSpecified = true,
+                comment = bhLineLoad.Name,
+
             };
 
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -53,18 +53,18 @@ namespace BH.Adapter.RFEM6
 
             if (orientationVector.X != 0)
             {
-                loadDirecteion = member_load_load_direction.LOAD_DIRECTION_LOCAL_X;
+                loadDirecteion = bhBarLoad.Projected? member_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED : member_load_load_direction.LOAD_DIRECTION_LOCAL_X;
                 loadMagintude = nodalLoadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.Length() : bhBarLoad.Moment.Length();
             }
             else if (orientationVector.Y != 0)
             {
-                loadDirecteion = member_load_load_direction.LOAD_DIRECTION_LOCAL_Y;
+                loadDirecteion = bhBarLoad.Projected ? member_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED : member_load_load_direction.LOAD_DIRECTION_LOCAL_Y;
                 loadMagintude = nodalLoadType == member_load_load_type.LOAD_TYPE_FORCE ? -1*bhBarLoad.Force.Length() : -1*bhBarLoad.Moment.Length();
 
             }
             else
             {
-                loadDirecteion = member_load_load_direction.LOAD_DIRECTION_LOCAL_Z;
+                loadDirecteion = bhBarLoad.Projected ? member_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_PROJECTED : member_load_load_direction.LOAD_DIRECTION_LOCAL_Z;
                 loadMagintude = nodalLoadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.Length() : bhBarLoad.Moment.Length();
             }
 
@@ -139,9 +139,14 @@ namespace BH.Adapter.RFEM6
 
             surface_load_load_direction loadDirecteion;
             Vector orientationVector = bhAreaLoad.Pressure;
-            if (orientationVector.X != 0) { loadDirecteion = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE; }
-            else if (orientationVector.Y != 0) { loadDirecteion = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE; }
-            else { loadDirecteion = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE; }
+            if (orientationVector.X != 0) { 
+                loadDirecteion = bhAreaLoad.Projected?surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED: surface_load_load_direction.LOAD_DIRECTION_LOCAL_X; }
+            else if (orientationVector.Y != 0) {
+                loadDirecteion = bhAreaLoad.Projected ? surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED : surface_load_load_direction.LOAD_DIRECTION_LOCAL_Y;
+            }
+            else {
+                loadDirecteion = bhAreaLoad.Projected ? surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_PROJECTED : surface_load_load_direction.LOAD_DIRECTION_LOCAL_Z;
+            }
 
 
             surface_load rfSurfaceLoad = new rfModel.surface_load()

--- a/RFEM6_Adapter/Convert/ToRFEM6/Type.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/Type.cs
@@ -107,7 +107,7 @@ namespace BH.Adapter.RFEM6
             }
             else if (bhType == typeof(GeometricalLineLoad))
             {
-                return rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD;
+                return rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD;
             }
             else if (bhType == typeof(AreaUniformlyDistributedLoad))
             {

--- a/RFEM6_Adapter/Modules/GetNonFreeLineLoadsModule.cs
+++ b/RFEM6_Adapter/Modules/GetNonFreeLineLoadsModule.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using BH.oM.Base;
+using BH.oM.Adapter;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using System.ComponentModel;
+using BH.oM.Structure.Elements;
+using System.Collections;
+using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
+using BH.oM.Structure.Loads;
+using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Loading.Interfaces;
+using BH.Engine.Base;
+
+namespace BH.Adapter.RFEM6
+{
+    [Description("Dependency module for fetching all IRFEMLineLoads stored in a list of Loadcombinations.")]
+    public class GetNonFreeLineLoadsModule : IGetDependencyModule<GeometricalLineLoad, IRFEMLineLoad>
+    {
+        public IEnumerable<IRFEMLineLoad> GetDependencies(IEnumerable<GeometricalLineLoad> lineLoads)
+        {
+            List<IRFEMLineLoad> rfLineLoad = new List<IRFEMLineLoad>();
+           
+            foreach (GeometricalLineLoad linload in lineLoads)
+            {
+
+                if (linload.Name.ToUpper().Equals("FREE"))
+                {
+
+                    RFEMFreeLineLoad rfFreeLineLoad = new RFEMFreeLineLoad() { geometrialLineLoad=linload};
+
+                     rfLineLoad.Add(rfFreeLineLoad);
+
+                }
+                else {
+
+
+                    RFEMNonFreeLineLoad rfFreeLineLoad = new RFEMNonFreeLineLoad() { geometrialLineLoad = linload };
+
+                    rfLineLoad.Add(rfFreeLineLoad);
+
+                }
+
+            }
+
+            return rfLineLoad;
+        }
+    }
+}

--- a/RFEM6_Adapter/Modules/GetPanelsFromArealoads.cs
+++ b/RFEM6_Adapter/Modules/GetPanelsFromArealoads.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using BH.oM.Base;
+using BH.oM.Adapter;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Reflection;
+using System.ComponentModel;
+using BH.oM.Structure.Elements;
+using System.Collections;
+using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
+using BH.oM.Structure.Loads;
+
+namespace BH.Adapter.RFEM6
+{
+    [Description("Dependency module for fetching all Loadcase stored in a list of Loadcombinations.")]
+    public class GetPanelFreomAreaUniformlyDistributedLoadModule : IGetDependencyModule<AreaUniformlyDistributedLoad, Panel>
+    {
+        public IEnumerable<Panel> GetDependencies(IEnumerable<AreaUniformlyDistributedLoad> objects)
+        {
+            HashSet<Panel> panels = new HashSet<Panel>(new RFEMPanelComparer());
+
+            foreach (AreaUniformlyDistributedLoad areaLoad in objects)
+            {
+
+                areaLoad.Objects.Elements.ForEach(x => panels.Add(x as Panel));
+
+            }
+
+            return panels;
+        }
+    }
+}

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -60,7 +60,7 @@ namespace BH.Adapter.RFEM6
         [Output("The created RFEM6 adapter.")]
         public RFEM6Adapter(bool active = false)
         {
-
+            
             // The Adapter constructor can be used to configure the Adapter behaviour.
             // For example:
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.FullPush; // Adapter `Push` Action simply calls "Create" method.
@@ -81,8 +81,8 @@ namespace BH.Adapter.RFEM6
                 //string modelUrl = application.new_model(modelName);
 
 
-                //model.reset();
-
+                //RfemApplicationClient rfemApplicationClient = new RfemApplicationClient(Binding, Address);
+                //rfemApplicationClient.open_model("C:\\Users\\michael\\Desktop\\RFEM\\TestModel.rf5");
 
             }
         }

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -65,6 +65,7 @@ namespace BH.Adapter.RFEM6
             // For example:
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.FullPush; // Adapter `Push` Action simply calls "Create" method.
             m_AdapterSettings.OnlyUpdateChangedObjects = false; // Setting this to true causes a Stackoverflow in some cases from the HashComparer called from the base FullCRUD.
+            m_AdapterSettings.CreateOnly_DistinctObjects = false; 
 
             AddAdapterModules();
 
@@ -74,27 +75,12 @@ namespace BH.Adapter.RFEM6
 
             AdapterIdFragmentType = typeof(RFEM6ID);
 
-            if (active)
-            {
-                // creates new model
-                //string modelName = "MyTestModel";
-                //string modelUrl = application.new_model(modelName);
-
-
-                //RfemApplicationClient rfemApplicationClient = new RfemApplicationClient(Binding, Address);
-                //rfemApplicationClient.open_model("C:\\Users\\michael\\Desktop\\RFEM\\TestModel.rf5");
-
-            }
         }
-
-        // You can add any other constructors that take more inputs here. 
 
         /***************************************************/
         /**** Private  Fields                           ****/
         /***************************************************/
 
-        //public HashSet<Constraint6DOF> m_LineSupport = new HashSet<Constraint6DOF>();
-        //public Dictionary<HashSet<Point>, int> m_PanelIdDictionary = new Dictionary<HashSet<Point>, int>();
         public Dictionary<Loadcase, Dictionary<String,int>> m_LoadcaseLoadIdDict = new Dictionary<Loadcase, Dictionary<String, int>>();
 
 

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -81,7 +81,9 @@ namespace BH.Adapter.RFEM6
         /**** Private  Fields                           ****/
         /***************************************************/
 
-        public Dictionary<Loadcase, Dictionary<String,int>> m_LoadcaseLoadIdDict = new Dictionary<Loadcase, Dictionary<String, int>>();
+        public Dictionary<Loadcase, Dictionary<String,int>> m_LoadcaseLoadIdDict = new Dictionary<Loadcase, Dictionary<String, int>>(new LoadCaseComparer());
+        public Dictionary<Panel, int> m_PanelIDdict = new Dictionary<Panel, int>(new RFEMPanelComparer());
+
 
 
         /***************************************************/

--- a/RFEM6_Adapter/RFEM6AdapterSettings.cs
+++ b/RFEM6_Adapter/RFEM6AdapterSettings.cs
@@ -73,9 +73,9 @@ namespace BH.Adapter.RFEM6
                 {typeof(RFEMOpening), new List<Type> { typeof(Edge)} },
                 {typeof(BarUniformlyDistributedLoad), new List<Type> { typeof(Bar),typeof(Loadcase)} },
                 {typeof(PointLoad), new List<Type> { typeof(Node), typeof(Loadcase) } },
-                //{typeof(IElementLoad<IAreaElement>), new List<Type> { typeof(Panel) } },
-                //{typeof(ILoad), new List<Type> { typeof(Loadcase), typeof(IElementLoad<IAreaElement>) } },
-                {typeof(AreaUniformlyDistributedLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } }
+                {typeof(AreaUniformlyDistributedLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } },
+                {typeof(GeometricalLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } }
+
 
             };
 
@@ -118,7 +118,7 @@ namespace BH.Adapter.RFEM6
                 {typeof(RFEMLine), new RFEMLineComparer(3) },
                 {typeof(Panel), new RFEMPanelComparer() },
                 {typeof(Loadcase), new LoadCaseComparer() },
-                {typeof(BarUniformlyDistributedLoad), new NameOrDescriptionComparer()},
+                //{typeof(BarUniformlyDistributedLoad), new NameOrDescriptionComparer()},
                 //{typeof(ILoad), new RFEMLoadComparer()  },
 
 

--- a/RFEM6_Adapter/RFEM6AdapterSettings.cs
+++ b/RFEM6_Adapter/RFEM6AdapterSettings.cs
@@ -47,6 +47,7 @@ using BH.Engine.Structure;
 using BH.Engine.Geometry;
 using BH.oM.Adapter;
 using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
+using System.Net.PeerToPeer.Collaboration;
 
 namespace BH.Adapter.RFEM6
 {
@@ -72,12 +73,14 @@ namespace BH.Adapter.RFEM6
                 {typeof(RFEMOpening), new List<Type> { typeof(Edge)} },
                 {typeof(BarUniformlyDistributedLoad), new List<Type> { typeof(Bar),typeof(Loadcase)} },
                 {typeof(PointLoad), new List<Type> { typeof(Node), typeof(Loadcase) } },
-                {typeof(GeometricalLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } },
-                {typeof(AreaUniformlyDistributedLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } },
+                //{typeof(IElementLoad<IAreaElement>), new List<Type> { typeof(Panel) } },
+                //{typeof(ILoad), new List<Type> { typeof(Loadcase), typeof(IElementLoad<IAreaElement>) } },
+                {typeof(AreaUniformlyDistributedLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } }
 
             };
-            
 
+            
+                //{ typeof(IElementLoad<Node>), new List<Type> { typeof(Node) } }
         }
 
         private void AddAdapterModules()
@@ -91,6 +94,7 @@ namespace BH.Adapter.RFEM6
             this.AdapterModules.Add(new GetLineFromBarModule());
             this.AdapterModules.Add(new GetLineFromEdgeModule());
             this.AdapterModules.Add(new GetOpeningFromOpeningModule());
+            //this.AdapterModules.Add(new GetPanelFreomAreaUniformlyDistributedLoadModule());
 
         }
 
@@ -114,7 +118,7 @@ namespace BH.Adapter.RFEM6
                 {typeof(RFEMLine), new RFEMLineComparer(3) },
                 {typeof(Panel), new RFEMPanelComparer() },
                 {typeof(Loadcase), new LoadCaseComparer() },
-                //{typeof(Point), new ComparerPoin },
+                {typeof(BarUniformlyDistributedLoad), new NameOrDescriptionComparer()},
                 //{typeof(ILoad), new RFEMLoadComparer()  },
 
 

--- a/RFEM6_Adapter/RFEM6AdapterSettings.cs
+++ b/RFEM6_Adapter/RFEM6AdapterSettings.cs
@@ -74,8 +74,8 @@ namespace BH.Adapter.RFEM6
                 {typeof(BarUniformlyDistributedLoad), new List<Type> { typeof(Bar),typeof(Loadcase)} },
                 {typeof(PointLoad), new List<Type> { typeof(Node), typeof(Loadcase) } },
                 {typeof(AreaUniformlyDistributedLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } },
-                {typeof(GeometricalLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } }
-
+                {typeof(GeometricalLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase), /*typeof(RFEMNonFreeLineLoad)*/ } },
+                //{typeof(RFEMNonFreeLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase), typeof(GeometricalLineLoad) } }
 
             };
 
@@ -94,7 +94,8 @@ namespace BH.Adapter.RFEM6
             this.AdapterModules.Add(new GetLineFromBarModule());
             this.AdapterModules.Add(new GetLineFromEdgeModule());
             this.AdapterModules.Add(new GetOpeningFromOpeningModule());
-            //this.AdapterModules.Add(new GetPanelFreomAreaUniformlyDistributedLoadModule());
+            //this.AdapterModules.Add(new GetNonFreeLineLoadsModule());
+
 
         }
 

--- a/RFEM6_oM/BHoMDataStructure/SupportDatastrures/RFEM6GeometricalLineLoadTypes.cs
+++ b/RFEM6_oM/BHoMDataStructure/SupportDatastrures/RFEM6GeometricalLineLoadTypes.cs
@@ -19,53 +19,27 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-using BH.oM.Base;
-using BH.oM.Adapter;
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
 using System.ComponentModel;
 using BH.oM.Structure.Elements;
-using System.Collections;
-using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
+using BH.oM.Structure.Constraints;
+using System.Security.Cryptography;
 using BH.oM.Structure.Loads;
 using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Loading.Interfaces;
-using BH.Engine.Base;
 using BH.oM.Adapters.RFEM6.Fragments.Enums;
 
-namespace BH.Adapter.RFEM6
+namespace BH.oM.Adapters.RFEM6.BHoMDataStructure.SupportDatastrures
 {
-    [Description("Dependency module for fetching all IRFEMLineLoads stored in a list of Loadcombinations.")]
-    public class GetNonFreeLineLoadsModule : IGetDependencyModule<GeometricalLineLoad, IRFEMLineLoad>
+    public class RFEM6GeometricalLineLoadTypes : IFragment
     {
-        public IEnumerable<IRFEMLineLoad> GetDependencies(IEnumerable<GeometricalLineLoad> lineLoads)
-        {
-            List<IRFEMLineLoad> rfLineLoad = new List<IRFEMLineLoad>();
-           
-            foreach (GeometricalLineLoad linload in lineLoads)
-            {
-
-                if (linload.Name.ToUpper().Equals("FREE"))
-                {
-
-                    RFEMFreeLineLoad rfFreeLineLoad = new RFEMFreeLineLoad() { geometrialLineLoad=linload};
-
-                     rfLineLoad.Add(rfFreeLineLoad);
-
-                }
-                else {
-
-
-                    RFEMNonFreeLineLoad rfFreeLineLoad = new RFEMNonFreeLineLoad() { geometrialLineLoad = linload };
-
-                    rfLineLoad.Add(rfFreeLineLoad);
-
-                }
-
-            }
-
-            return rfLineLoad;
-        }
+        public GeometricalLineLoadTypesEnum geometrialLineLoadType { set; get; }
     }
+
+
+
 }

--- a/RFEM6_oM/Fragments/Enums/GeometricalLineLoadTypesEnum.cs
+++ b/RFEM6_oM/Fragments/Enums/GeometricalLineLoadTypesEnum.cs
@@ -19,53 +19,31 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-using BH.oM.Base;
-using BH.oM.Adapter;
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Reflection;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
 using System.ComponentModel;
 using BH.oM.Structure.Elements;
-using System.Collections;
-using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
+using BH.oM.Structure.Constraints;
+using System.Security.Cryptography;
 using BH.oM.Structure.Loads;
 using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Loading.Interfaces;
-using BH.Engine.Base;
-using BH.oM.Adapters.RFEM6.Fragments.Enums;
 
-namespace BH.Adapter.RFEM6
+namespace BH.oM.Adapters.RFEM6.Fragments.Enums
 {
-    [Description("Dependency module for fetching all IRFEMLineLoads stored in a list of Loadcombinations.")]
-    public class GetNonFreeLineLoadsModule : IGetDependencyModule<GeometricalLineLoad, IRFEMLineLoad>
+    public enum GeometricalLineLoadTypesEnum  
     {
-        public IEnumerable<IRFEMLineLoad> GetDependencies(IEnumerable<GeometricalLineLoad> lineLoads)
-        {
-            List<IRFEMLineLoad> rfLineLoad = new List<IRFEMLineLoad>();
-           
-            foreach (GeometricalLineLoad linload in lineLoads)
-            {
+        [Description("Definitin of Free Line Load in RFEM6.")]
+        FreeLineLoad = 0,
+        [Description("Definitin of Line Load in RFEM6.")]
+        NonFreeLineLoad = 1,
+     
 
-                if (linload.Name.ToUpper().Equals("FREE"))
-                {
-
-                    RFEMFreeLineLoad rfFreeLineLoad = new RFEMFreeLineLoad() { geometrialLineLoad=linload};
-
-                     rfLineLoad.Add(rfFreeLineLoad);
-
-                }
-                else {
-
-
-                    RFEMNonFreeLineLoad rfFreeLineLoad = new RFEMNonFreeLineLoad() { geometrialLineLoad = linload };
-
-                    rfLineLoad.Add(rfFreeLineLoad);
-
-                }
-
-            }
-
-            return rfLineLoad;
-        }
     }
+
+
+
 }

--- a/RFEM6_oM/IntermediateDatastructure/Loading/Interfaces/IRFEMLineLoad.cs
+++ b/RFEM6_oM/IntermediateDatastructure/Loading/Interfaces/IRFEMLineLoad.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using System.ComponentModel;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Constraints;
+using System.Security.Cryptography;
+using BH.oM.Structure.Loads;
+
+namespace BH.oM.Adapters.RFEM6.IntermediateDatastructure.Loading.Interfaces
+{
+    public interface IRFEMLineLoad:IBHoMObject
+    {
+
+        GeometricalLineLoad geometrialLineLoad { get; set; }
+
+
+
+    }
+
+}

--- a/RFEM6_oM/IntermediateDatastructure/Loading/RFEMFreeLineLoad.cs
+++ b/RFEM6_oM/IntermediateDatastructure/Loading/RFEMFreeLineLoad.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using System.ComponentModel;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Constraints;
+using System.Security.Cryptography;
+using BH.oM.Structure.Loads;
+using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Loading.Interfaces;
+
+namespace BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry
+{
+    public class RFEMFreeLineLoad : GeometricalLineLoad, IRFEMLineLoad
+    {
+       public GeometricalLineLoad geometrialLineLoad { set; get; }
+    }
+
+
+
+}

--- a/RFEM6_oM/IntermediateDatastructure/Loading/RFEMNonFreeLineLoad.cs
+++ b/RFEM6_oM/IntermediateDatastructure/Loading/RFEMNonFreeLineLoad.cs
@@ -1,0 +1,46 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using System.ComponentModel;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Constraints;
+using System.Security.Cryptography;
+using BH.oM.Structure.Loads;
+using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Loading.Interfaces;
+
+namespace BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry
+{
+    public class RFEMNonFreeLineLoad : GeometricalLineLoad, IRFEMLineLoad
+    {
+
+        public GeometricalLineLoad geometrialLineLoad { set; get; }
+
+    }
+
+
+
+}

--- a/RFEM6_oM/RFEM6_oM.csproj
+++ b/RFEM6_oM/RFEM6_oM.csproj
@@ -42,10 +42,6 @@
 		</Reference>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="IntermediateDatastructure\Loading\" />
-	</ItemGroup>
-
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
 		<Exec Command="if not &quot;$(ConfigurationName)&quot; == &quot;Test&quot; (xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y)" />
 	</Target>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #40 
Closes #38 

<!-- Add short description of what has been fixed -->
This PR should enable the user to both push and pull line loads and panel loads into RFEM6.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Testfile](https://burohappold.sharepoint.com/:u:/s/BHoM/EfylUtFi8chCsgq5lzz3jesB1enHSrh-P4MNRsA1lcxZkg?e=GCbVFm)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Alteration of Create method. Added sections in charge of creation for Lineloads, Free Lineloads and UDL Arealoads. 
- Added Read Methods ReadLineLoad, ReadFreeLineLoad and ReadAreaLoad. 

### Additional comments
<!-- As required -->
The push of both types of line loads and the area loads should take place in a two-stage push. This means that the push of the geometrical elements, such as panels, should occur in a previous push, while the push of the load itself should be carried out in a second push.

It is important to note that the loads will not be overwritten when altering (or not altering) loads and pushing them again. Generally, loads should always be defined using vectors parallel to the X, Y, or Z-axis.

In terms of load types, when pushing, Free Line Loads support only the 'Force' type due to restrictions in RFEM6 (this is not a BHoM issue). The 'Force' type can only be linear, which also includes uniformly distributed loads, over the entire line. In comparison, Line Loads support both Moments and Forces, but not in combination. The load distribution is trapezoidal over the entire line, which includes UDL (Uniformly Distributed Load) or linear load.