### PR TITLE
Push/Pull user defined comments to/from RFEM6

### DIFF
--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Bar.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Bar.cs
@@ -42,6 +42,7 @@ namespace BH.Adapter.RFEM6
 
 
             Bar bar = new Bar { Start = node0, End = node1, SectionProperty = section, Name = "member nr." + member.no, FEAType = member.type.FromRFEM() };
+            BH.Engine.Base.Modify.SetPropertyValue(bar, "Comment", member.comment);
             bar.SetRFEM6ID(member.no);
             return bar;
         }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Material.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Material.cs
@@ -32,6 +32,7 @@ using BH.oM.Structure.MaterialFragments;
 
 using rfModel = Dlubal.WS.Rfem6.Model;
 using BH.Engine.Base;
+using Dlubal.WS.Rfem6.Model;
 
 namespace BH.Adapter.RFEM6
 {
@@ -50,6 +51,7 @@ namespace BH.Adapter.RFEM6
             {
 
                 bhMaterial = BH.Engine.Library.Query.Match("Steel", rfMaterial.name.Split('|')[0], true, true).DeepClone() as IMaterialFragment;
+
 
             }
 
@@ -80,6 +82,7 @@ namespace BH.Adapter.RFEM6
 
             }
             bhMaterial.SetRFEM6ID(rfMaterial.no);
+            BH.Engine.Base.Modify.SetPropertyValue(bhMaterial, "Comment", rfMaterial.comment);
             return bhMaterial;
         }
 

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Node.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Node.cs
@@ -30,6 +30,7 @@ using BH.Engine.Adapter;
 using BH.oM.Adapters.RFEM6;
 
 using rfModel = Dlubal.WS.Rfem6.Model;
+using Dlubal.WS.Rfem6.Model;
 
 namespace BH.Adapter.RFEM6
 {
@@ -43,6 +44,7 @@ namespace BH.Adapter.RFEM6
 
             bhNode.Name = "Node Nr. " + node.no;
             bhNode.SetRFEM6ID(node.no);
+            BH.Engine.Base.Modify.SetPropertyValue(bhNode, "Comment", node.comment);
             return bhNode;
         }
 

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Opening.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Opening.cs
@@ -33,6 +33,7 @@ using BH.Engine.Adapter;
 using rfModel = Dlubal.WS.Rfem6.Model;
 using BH.Engine.Geometry;
 using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
+using Dlubal.WS.Rfem6.Model;
 
 namespace BH.Adapter.RFEM6
 {
@@ -63,6 +64,7 @@ namespace BH.Adapter.RFEM6
             RFEMOpening rfemOpening = new RFEMOpening() { Opening = o, SurfaceIDs = surfaceIDs };
 
             rfemOpening.SetRFEM6ID(rfOpening.no);
+            BH.Engine.Base.Modify.SetPropertyValue(rfemOpening, "Comment", rfOpening.comment);
             return rfemOpening;
 
         }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Panel.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Panel.cs
@@ -34,6 +34,7 @@ using rfModel = Dlubal.WS.Rfem6.Model;
 using BH.Engine.Spatial;
 using BH.Engine.Base;
 using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
+using Dlubal.WS.Rfem6.Model;
 
 namespace BH.Adapter.RFEM6
 {
@@ -80,6 +81,7 @@ namespace BH.Adapter.RFEM6
             }
 
             panel.SetRFEM6ID(rfSurface.no);
+            BH.Engine.Base.Modify.SetPropertyValue(panel, "Comment", rfSurface.comment);
 
             return panel;
         }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -88,7 +88,18 @@ namespace BH.Adapter.RFEM6
             }
 
             bhSection.SetRFEM6ID(section.no);
-            BH.Engine.Base.Modify.SetPropertyValue(bhSection, "Comment", section.comment);
+
+            if (section.comment.Contains("BHComment")) { 
+            
+                string sectionComment = "";
+                
+                sectionComment = section.comment.Split(';').ToList().Last();
+            
+                BH.Engine.Base.Modify.SetPropertyValue(bhSection, "Comment", sectionComment);
+            
+            }
+            
+            
 
             return bhSection;
         }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -88,6 +88,7 @@ namespace BH.Adapter.RFEM6
             }
 
             bhSection.SetRFEM6ID(section.no);
+            BH.Engine.Base.Modify.SetPropertyValue(bhSection, "Comment", section.comment);
 
             return bhSection;
         }

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Bar.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Bar.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.RFEM6
                 section_start = bar.SectionProperty.GetRFEM6ID(),
                 section_startSpecified = true,
                 section_endSpecified = true,
-                comment = "",
+                comment = "BHoMName:"+bar.Name
             };
 
             return rfMember;

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Bar.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Bar.cs
@@ -38,8 +38,8 @@ namespace BH.Adapter.RFEM6
     {
         public static rfModel.member ToRFEM6(this Bar bar)
         {
-            Object value="";
-            bar.CustomData.TryGetValue("Comment", out value);
+            Object bhComment="";
+            bar.CustomData.TryGetValue("Comment", out bhComment);
            
 
 
@@ -55,7 +55,7 @@ namespace BH.Adapter.RFEM6
                 section_start = bar.SectionProperty.GetRFEM6ID(),
                 section_startSpecified = true,
                 section_endSpecified = true,
-                comment = "BHoMName: "+(String)value,
+                comment = (String)(bhComment==null ? "" : $"BHComment:{bhComment}"),
                
             };
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Bar.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Bar.cs
@@ -38,6 +38,13 @@ namespace BH.Adapter.RFEM6
     {
         public static rfModel.member ToRFEM6(this Bar bar)
         {
+            Object value="";
+            bar.CustomData.TryGetValue("Comment", out value);
+           
+
+
+            
+
             rfModel.member rfMember = new rfModel.member()
             {
                 no = bar.GetRFEM6ID(),
@@ -48,7 +55,8 @@ namespace BH.Adapter.RFEM6
                 section_start = bar.SectionProperty.GetRFEM6ID(),
                 section_startSpecified = true,
                 section_endSpecified = true,
-                comment = "BHoMName:"+bar.Name
+                comment = "BHoMName: "+(String)value,
+               
             };
 
             return rfMember;

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Material.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Material.cs
@@ -41,12 +41,14 @@ namespace BH.Adapter.RFEM6
         {
             rfModel.material_material_type materialType = GetMaterialType(material);
             string materialName = GetMaterialName(material);
+            Object value = "";
+            material.CustomData.TryGetValue("Comment", out value);
 
             rfModel.material rfMaterial = new rfModel.material
             {
                 no = material.GetRFEM6ID(),
                 name = materialName,
-                comment = "",
+                comment = "BHoMName: " + (String)value,
                 material_type = materialType
             };
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Material.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Material.cs
@@ -41,14 +41,14 @@ namespace BH.Adapter.RFEM6
         {
             rfModel.material_material_type materialType = GetMaterialType(material);
             string materialName = GetMaterialName(material);
-            Object value = "";
-            material.CustomData.TryGetValue("Comment", out value);
+            Object bhComment = "";
+            material.CustomData.TryGetValue("Comment", out bhComment);
 
             rfModel.material rfMaterial = new rfModel.material
             {
                 no = material.GetRFEM6ID(),
                 name = materialName,
-                comment = "BHoMName: " + (String)value,
+                comment = (String)(bhComment==null ? "" : $"BHComment:{bhComment}"),
                 material_type = materialType
             };
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Node.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Node.cs
@@ -39,8 +39,8 @@ namespace BH.Adapter.RFEM6
 
         public static rfModel.node ToRFEM6(this Node node)
         {
-            Object value = "";
-            node.CustomData.TryGetValue("Comment", out value);
+            Object bhComment = "";
+            node.CustomData.TryGetValue("Comment", out bhComment);
 
             rfModel.node rfNode = new rfModel.node()
             {
@@ -48,7 +48,7 @@ namespace BH.Adapter.RFEM6
                 coordinates = new rfModel.vector_3d() { x = node.Position.X, y = node.Position.Y, z = node.Position.Z },
                 coordinate_system_type = rfModel.node_coordinate_system_type.COORDINATE_SYSTEM_CARTESIAN,
                 coordinate_system_typeSpecified = true,
-                comment = "BHoMName: " + (String)value,
+                comment = (String)(bhComment == null ? "" : $"BHComment:{bhComment}"),
             };
 
             return rfNode;

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Node.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Node.cs
@@ -39,6 +39,8 @@ namespace BH.Adapter.RFEM6
 
         public static rfModel.node ToRFEM6(this Node node)
         {
+            Object value = "";
+            node.CustomData.TryGetValue("Comment", out value);
 
             rfModel.node rfNode = new rfModel.node()
             {
@@ -46,7 +48,7 @@ namespace BH.Adapter.RFEM6
                 coordinates = new rfModel.vector_3d() { x = node.Position.X, y = node.Position.Y, z = node.Position.Z },
                 coordinate_system_type = rfModel.node_coordinate_system_type.COORDINATE_SYSTEM_CARTESIAN,
                 coordinate_system_typeSpecified = true,
-                comment = ""
+                comment = "BHoMName: " + (String)value,
             };
 
             return rfNode;

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Opening.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Opening.cs
@@ -33,6 +33,7 @@ using BH.oM.Geometry;
 using rfModel = Dlubal.WS.Rfem6.Model;
 using Dlubal.WS.Rfem6.Model;
 using BH.Engine.Base;
+using Newtonsoft.Json.Linq;
 
 namespace BH.Adapter.RFEM6
 {
@@ -43,12 +44,15 @@ namespace BH.Adapter.RFEM6
         {
 
             List<int> edgeIdList = new List<int>();
+            Object value = "";
+            bhOpening.CustomData.TryGetValue("Comment", out value);
 
 
             rfModel.opening rfSurface = new opening
             {
                 no = bhOpening.GetRFEM6ID(),
                 boundary_lines = bhOpening.Edges.Select(b => b.GetRFEM6ID()).ToArray(),
+                comment = "BHoMName: " + (String)value,
 
             };
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Opening.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Opening.cs
@@ -34,6 +34,7 @@ using rfModel = Dlubal.WS.Rfem6.Model;
 using Dlubal.WS.Rfem6.Model;
 using BH.Engine.Base;
 using Newtonsoft.Json.Linq;
+using System.Xml.Linq;
 
 namespace BH.Adapter.RFEM6
 {
@@ -44,22 +45,18 @@ namespace BH.Adapter.RFEM6
         {
 
             List<int> edgeIdList = new List<int>();
-            Object value = "";
-            bhOpening.CustomData.TryGetValue("Comment", out value);
+            Object bhComment = "";
+            bhOpening.CustomData.TryGetValue("Comment", out bhComment);
 
 
             rfModel.opening rfSurface = new opening
             {
                 no = bhOpening.GetRFEM6ID(),
                 boundary_lines = bhOpening.Edges.Select(b => b.GetRFEM6ID()).ToArray(),
-                comment = "BHoMName: " + (String)value,
-
+                comment = (String)(bhComment.Equals("") ? bhComment : $"BHComment:{bhComment}"),
             };
-
             return rfSurface;
-
         }
-
     }
 }
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Panel.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Panel.cs
@@ -44,8 +44,8 @@ namespace BH.Adapter.RFEM6
 
             List<int> edgeIdList = new List<int>();
             bhPanel.ExternalEdges.ForEach(e => edgeIdList.Add(e.GetRFEM6ID()));
-            Object value = "";
-            bhPanel.CustomData.TryGetValue("Comment", out value);
+            Object bhComment = "";
+            bhPanel.CustomData.TryGetValue("Comment", out bhComment);
 
             rfModel.surface rfSurface = new rfModel.surface
             {
@@ -56,7 +56,7 @@ namespace BH.Adapter.RFEM6
                 boundary_lines = edgeIdList.ToArray(),
                 type = surface_type.TYPE_STANDARD,
                 typeSpecified = true,
-                comment = "BHoMName: " + (String)value,
+                comment = (String)(bhComment==null ? "" : $"BHComment:{bhComment}"),
 
             };
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Panel.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/Panel.cs
@@ -44,6 +44,8 @@ namespace BH.Adapter.RFEM6
 
             List<int> edgeIdList = new List<int>();
             bhPanel.ExternalEdges.ForEach(e => edgeIdList.Add(e.GetRFEM6ID()));
+            Object value = "";
+            bhPanel.CustomData.TryGetValue("Comment", out value);
 
             rfModel.surface rfSurface = new rfModel.surface
             {
@@ -54,6 +56,7 @@ namespace BH.Adapter.RFEM6
                 boundary_lines = edgeIdList.ToArray(),
                 type = surface_type.TYPE_STANDARD,
                 typeSpecified = true,
+                comment = "BHoMName: " + (String)value,
 
             };
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -48,7 +48,8 @@ namespace BH.Adapter.RFEM6
             rfModel.section rfSection = null;
             // create section
             int secNo = bhSection.GetRFEM6ID();
-            
+            Object bhComment = "";
+            bhSection.CustomData.TryGetValue("Comment", out bhComment);
 
             rfSection = new rfModel.section
             {
@@ -58,7 +59,7 @@ namespace BH.Adapter.RFEM6
                 materialSpecified = true,
                 typeSpecified = true,
                 type = rfModel.section_type.TYPE_PARAMETRIC_MASSIVE_I,
-                comment = $"GenericSection Name:{bhSection.Name}",
+                comment = $"GenericSection Name:{bhSection.Name}"+(bhComment==null?" ":$";BHComment:{bhComment}"),
 
             };
 
@@ -111,8 +112,8 @@ namespace BH.Adapter.RFEM6
             AlterSectionName(bhSection);
 
             int secNo = bhSection.GetRFEM6ID();
-            Object value = "";
-            bhSection.CustomData.TryGetValue("Comment", out value);
+            Object bhComment = "";
+            bhSection.CustomData.TryGetValue("Comment", out bhComment);
 
             if (materialType.Equals("Steel"))
             {
@@ -133,7 +134,7 @@ namespace BH.Adapter.RFEM6
                         manufacturing_typeSpecified = true,
                         thin_walled_model = true,
                         thin_walled_modelSpecified = true,
-                        comment = "BHoMName: " + (String)value,
+                        comment = (String)(bhComment==null ? "" : $"BHComment:{bhComment}"),    
                     };
 
                 }
@@ -154,7 +155,7 @@ namespace BH.Adapter.RFEM6
                         manufacturing_type = rfModel.section_manufacturing_type.MANUFACTURING_TYPE_WELDED,
                         manufacturing_typeSpecified = true,
                         name = bhSection.Name, // width as in RFEM
-                        comment = "BHoMName: " + (String)value,
+                        comment = (String)(bhComment == null ? "" : $"BHComment:{bhComment}"),
 
                     };
 
@@ -174,7 +175,7 @@ namespace BH.Adapter.RFEM6
                     parametrization_type = GetParametrizationType(bhSection, materialType),
                     parametrization_typeSpecified = true,
                     name = bhSection.Name, // width/height as in RFEM, SI units
-                    comment = "BHoMName: " + (String)value,
+                    comment = (String)(bhComment == null ? "" : $"BHComment:{bhComment}") 
                 };
 
             }

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -48,8 +48,7 @@ namespace BH.Adapter.RFEM6
             rfModel.section rfSection = null;
             // create section
             int secNo = bhSection.GetRFEM6ID();
-          
-
+            
 
             rfSection = new rfModel.section
             {
@@ -112,6 +111,8 @@ namespace BH.Adapter.RFEM6
             AlterSectionName(bhSection);
 
             int secNo = bhSection.GetRFEM6ID();
+            Object value = "";
+            bhSection.CustomData.TryGetValue("Comment", out value);
 
             if (materialType.Equals("Steel"))
             {
@@ -132,6 +133,7 @@ namespace BH.Adapter.RFEM6
                         manufacturing_typeSpecified = true,
                         thin_walled_model = true,
                         thin_walled_modelSpecified = true,
+                        comment = "BHoMName: " + (String)value,
                     };
 
                 }
@@ -152,6 +154,7 @@ namespace BH.Adapter.RFEM6
                         manufacturing_type = rfModel.section_manufacturing_type.MANUFACTURING_TYPE_WELDED,
                         manufacturing_typeSpecified = true,
                         name = bhSection.Name, // width as in RFEM
+                        comment = "BHoMName: " + (String)value,
 
                     };
 
@@ -171,6 +174,7 @@ namespace BH.Adapter.RFEM6
                     parametrization_type = GetParametrizationType(bhSection, materialType),
                     parametrization_typeSpecified = true,
                     name = bhSection.Name, // width/height as in RFEM, SI units
+                    comment = "BHoMName: " + (String)value,
                 };
 
             }
@@ -184,7 +188,6 @@ namespace BH.Adapter.RFEM6
 
 
             string materialType = bhSection.Material.GetType().Name;
-
             //Parametrs for dimensioning Cross Sections
             double v0, v1, v2, v3, v4, v5;
 


### PR DESCRIPTION
 
### Issues addressed by this PR
Resolves #21 

Now users can add comments to bars, materials, openings, panels, and surface and section properties. To create a comment, utilize the BHoM set property component by adding a property named ‘Comment'.

### Test files
[File](https://burohappold.sharepoint.com/:u:/s/BHoM/EQMXnFazsMRDvxQZ2FOoYkUBZUwvK3AuUF2Vu6Z6Fo8VKw?e=lazJVK)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Added create comment line to the corresponding RFEM Objects within the ToRFEM6 Conversion methods.
- Added read comment functionlaity to the corresponding RFEM Objects within the FromRFEM6 Conversion methods.