### PR TITLE
Uniformly Distributed Area Loads Not pushing

### DIFF
--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.RFEM6
 {
     public partial class RFEM6Adapter
     {
-
+        
         private bool CreateCollection(IEnumerable<ILoad> bhLoads)
         {
             //Container for Potential Surface IDs. Surface IDs are onle relevant when using Free Line Loads
@@ -60,8 +60,11 @@ namespace BH.Adapter.RFEM6
 
                 if (bhLoad is AreaUniformlyDistributedLoad)
                 {
-
+                    // Updating the load dictionary
                     UpdateLoadIdDictionary(bhLoad);
+
+                    //Call Panel Load Methond to update the Panel ID Dictionary
+                    this.GetCachedOrReadAsDictionary<int, Panel>();
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
                     surface_load rfemAreaLoad = (bhLoad as AreaUniformlyDistributedLoad).ToRFEM6(id);
                     var currrSurfaceIds = (bhLoad as AreaUniformlyDistributedLoad).Objects.Elements.ToList().Select(e => m_PanelIDdict[e as Panel]).ToArray();


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
The application of uniformly distributed loads does cause some errors. This PR should resolve the issue, enabling users to apply loads properly.

Closes #73 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Link](https://burohappold.sharepoint.com/:u:/s/BHoM/EetspdKfLHRMr5TOWAeOLXcByWZo0Hz5DGwx1tYqTiaZqA?e=5NgKAJ)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Read Panel method called within the create UDL method. 
- Read Malen Method does make sure that the ID is getting stored withing a dictionary. 

### Additional comments
<!-- As required -->
