### PR TITLE
Enabling Push of Multiple Load Cases of Equal Load Nature.

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/Loadcase.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/Loadcase.cs
@@ -1,0 +1,191 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using BH.Adapter.RFEM6;
+using BH.Engine.Base;
+using BH.oM.Data.Requests;
+using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Structure;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Geometry;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Loads;
+using Dlubal.WS.Rfem6.Model;
+using BH.Engine.Geometry;
+using System.Security.Permissions;
+using BH.oM.Base;
+
+namespace RFEM_Toolkit_Test.Elements
+{
+
+
+    public class LoadCase_Test
+
+    {
+
+        RFEM6Adapter adapter;
+
+        Loadcase loadcase1;
+        Loadcase loadcase2;
+        Loadcase loadcase3;
+        Loadcase loadcase4;
+        Loadcase loadcase5;
+        Loadcase loadcase6;
+        Loadcase loadcase7;
+        Loadcase loadcase8;
+        Loadcase loadcase9;
+        Loadcase loadcase10;
+        Loadcase loadcase11;
+        Loadcase loadcase12;
+        Loadcase loadcase1_1NonDL;
+
+        List<Loadcase> loadCaseList;
+
+        //[TearDown]
+        //public void TearDown()
+        //{
+        //    adapter.Wipeout();
+        //}
+
+        [SetUp]
+        public void EveryTimeSetUp()
+        {
+            //adapter = new RFEM6Adapter(true);
+            loadcase1 = new Loadcase() { Name = "LC1", Nature = LoadNature.Dead, Number = 1 };
+            loadcase2 = new Loadcase() { Name = "LC2", Nature = LoadNature.Accidental, Number = 2 };
+            loadcase3 = new Loadcase() { Name = "LC3", Nature = LoadNature.Live, Number = 3 };
+            loadcase4 = new Loadcase() { Name = "LC4", Nature = LoadNature.Notional, Number = 4 };//Recognized as Dead
+            loadcase5 = new Loadcase() { Name = "LC5", Nature = LoadNature.Other, Number = 5 };//recognized as Dead
+            loadcase6 = new Loadcase() { Name = "LC6", Nature = LoadNature.Prestress, Number = 6 };
+            loadcase7 = new Loadcase() { Name = "LC7", Nature = LoadNature.Seismic, Number = 7 };
+            loadcase8 = new Loadcase() { Name = "LC8", Nature = LoadNature.Snow, Number = 8 };
+            loadcase9 = new Loadcase() { Name = "LC9", Nature = LoadNature.SuperDead, Number = 9 };
+            loadcase10 = new Loadcase() { Name = "LC10", Nature = LoadNature.Temperature, Number = 10 };
+            loadcase11 = new Loadcase() { Name = "LC11", Nature = LoadNature.Wind, Number = 11 };
+            loadcase12 = new Loadcase() { Name = "LC12", Nature = LoadNature.Wind };
+
+            loadcase1_1NonDL = new Loadcase() { Name = "NumberNaturMissmatch", Nature = LoadNature.Wind, Number = 1 };
+
+
+            loadCaseList = new List<Loadcase>() { loadcase1, loadcase2, loadcase3, loadcase4, loadcase5, loadcase6, loadcase7, loadcase8, loadcase9, loadcase10, loadcase11, loadcase12 };
+        }
+
+        [OneTimeSetUp]
+        public void SetUpScenario()
+        {
+            adapter = new RFEM6Adapter(true);
+
+        }
+
+        [Test]
+        public void PushPullOrder()
+        {
+            //Reverse List
+            loadCaseList.Reverse();
+            adapter.Push(loadCaseList);
+
+            //Reverse list bakc to normal
+            loadCaseList.Reverse();
+            adapter.Pull(new FilterRequest() { Type = typeof(Loadcase) });
+            List<Loadcase> pulledLoadCases = adapter.Pull(new FilterRequest() { Type = typeof(Loadcase) }).ToList().Select(p => (Loadcase)p).ToList();
+
+            int i = 0;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+            i = 1;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+            i=2;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+            i = 3;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(LoadNature.Dead));
+
+            i = 4;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(LoadNature.Dead));
+
+            i = 5;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+            i = 6;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+            i = 7;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+            i = 8;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+            i = 9;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+            i = 10;
+            Assert.IsTrue(pulledLoadCases[i].Name.Equals(loadCaseList[i].Name));
+            Assert.IsTrue(pulledLoadCases[i].Number.Equals(loadCaseList[i].Number));
+            Assert.IsTrue(pulledLoadCases[i].Nature.Equals(loadCaseList[i].Nature));
+
+           
+
+        }
+
+        [Test]
+        public void PushPullNo1NonDeadLoad()
+        {
+            adapter.Push(new List<Loadcase>() { loadcase1_1NonDL });
+
+            adapter.Pull(new FilterRequest() { Type = typeof(Loadcase) });
+            List<Loadcase> pulledLoadCases = adapter.Pull(new FilterRequest() { Type = typeof(Loadcase) }).ToList().Select(p => (Loadcase)p).ToList();
+            
+            Assert.IsTrue(pulledLoadCases[0].Name.Equals(loadcase1_1NonDL.Name));
+            Assert.IsTrue(pulledLoadCases[0].Nature.Equals(LoadNature.Dead));
+            Assert.IsTrue(pulledLoadCases[0].Number.Equals(loadcase1_1NonDL.Number));
+
+
+
+
+
+        }
+
+
+
+
+    }
+}

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -214,6 +214,7 @@ namespace BH.Adapter.RFEM6
             return true;
         }
 
+        //Metho checks if ILoad is either a Moment or a Force Load
         private object MomentOfForceLoad(ILoad bhLoad)
         {
 

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Loadcase.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Loadcase.cs
@@ -83,7 +83,7 @@ namespace BH.Adapter.RFEM6
             foreach (Loadcase loadCase in bhLoadCase)
             {
                 // If Load case number has not been set use the next free number
-                if (loadCase.Number==0) { 
+                if (loadCase.Number<1) { 
                 
                    int n= m_Model.get_first_free_number(rfModel.object_types.E_OBJECT_TYPE_LOAD_CASE, 0);
                    loadCase.Number = n;

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Loadcase.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Loadcase.cs
@@ -39,19 +39,24 @@ namespace BH.Adapter.RFEM6
 
         private List<Loadcase> ReadLoadCase(List<string> ids = null)
         {
-
+            // Get all Loadcases from RFEM6
             rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LOAD_CASE);
             IEnumerable<rfModel.load_case> foundLoadCases = numbers.ToList().Select(n => m_Model.get_load_case(n.no));
 
             List<Loadcase> loadCases = new List<Loadcase>();
+           
+            // Convert the RFEM Loadcases to BHoM Loadcases
             foreach (rfModel.load_case loadCase in foundLoadCases)
             {
 
-                //lcName.Add(loadCase.action_category);
-                //Console.WriteLine(loadCase.action_category);
                 loadCases.Add(loadCase.FromRFEM());
 
             }
+
+
+
+            // Sort the Loadcases by Number
+            loadCases.Sort((x, y) => x.Number.CompareTo(y.Number));
 
             return loadCases;
         }

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Loadcase.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Loadcase.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.RFEM6
 
             load_case rfLoadCase = new rfModel.load_case()
             {
-                no = bhLoadcase.GetRFEM6ID(),
+                no = bhLoadcase.Number,
                 name = bhLoadcase.Name,
                 static_analysis_settings = analysisNo,
                 analysis_type = load_case_analysis_type.ANALYSIS_TYPE_STATIC,
@@ -59,7 +59,7 @@ namespace BH.Adapter.RFEM6
                 stability_analysis_settingsSpecified = true,
             };
 
-            
+
             return rfLoadCase;
 
         }
@@ -67,7 +67,10 @@ namespace BH.Adapter.RFEM6
         private static String ToRFEM(this LoadNature loadNature)
         {
 
-
+            if (loadNature.Equals(LoadNature.Notional) || loadNature.Equals(LoadNature.Other))
+            {
+                BH.Engine.Base.Compute.RecordWarning($"Load cases of Nature Type {loadNature} will be pushed as Dead Load, as RFEM6 has no corresponding LoadNature!");
+            }
 
             switch (loadNature)
             {

--- a/RFEM6_Adapter/RFEM6AdapterSettings.cs
+++ b/RFEM6_Adapter/RFEM6AdapterSettings.cs
@@ -74,18 +74,14 @@ namespace BH.Adapter.RFEM6
                 {typeof(BarUniformlyDistributedLoad), new List<Type> { typeof(Bar),typeof(Loadcase)} },
                 {typeof(PointLoad), new List<Type> { typeof(Node), typeof(Loadcase) } },
                 {typeof(AreaUniformlyDistributedLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } },
-                {typeof(GeometricalLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase), /*typeof(RFEMNonFreeLineLoad)*/ } },
-                //{typeof(RFEMNonFreeLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase), typeof(GeometricalLineLoad) } }
+                {typeof(GeometricalLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase)} },
 
             };
 
-            
-                //{ typeof(IElementLoad<Node>), new List<Type> { typeof(Node) } }
         }
 
         private void AddAdapterModules()
         {
-
 
             BH.Adapter.Modules.Structure.ModuleLoader.LoadModules(this);
             this.AdapterModules.Add(new GetRFEMNodalSupportModule());
@@ -94,14 +90,11 @@ namespace BH.Adapter.RFEM6
             this.AdapterModules.Add(new GetLineFromBarModule());
             this.AdapterModules.Add(new GetLineFromEdgeModule());
             this.AdapterModules.Add(new GetOpeningFromOpeningModule());
-            //this.AdapterModules.Add(new GetNonFreeLineLoadsModule());
-
 
         }
 
         private Dictionary<Type, object> GenerateAdapterComparersSettings()
         {
-
 
             return new Dictionary<Type, object>
             {
@@ -119,11 +112,6 @@ namespace BH.Adapter.RFEM6
                 {typeof(RFEMLine), new RFEMLineComparer(3) },
                 {typeof(Panel), new RFEMPanelComparer() },
                 {typeof(Loadcase), new LoadCaseComparer() },
-                //{typeof(BarUniformlyDistributedLoad), new NameOrDescriptionComparer()},
-                //{typeof(ILoad), new RFEMLoadComparer()  },
-
-
-
             };
              
            


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Previously, the push of LoadCases was restricted so that users could only push a single Loadcase of a specific Nature into RFEM6. However, as users might want to define multiple Loadcases representing e.g. wind loads it was necessary to resolve this issue. Additionally, additionally users were not able to use  the “Numbers input” for Loadcases, which defines the LoadCase ID in RFEM6. It’s essential to note that LoadCase with Number 1 should always represent dead load. If it doesn’t, the LoadCase will be transformed into a Nature Deadload. When the number of Loads is less than 1, appropriate alternatives will be defined by the adapter.

Closes #62 
Closes #42 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File](https://burohappold.sharepoint.com/:u:/s/BHoM/EW0s74RmXVJMrJORZBCYKuMBT7v53s04skSifgoNRDv80w?e=mc0NFZ)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Adding Unittest for Loadcases
- Minor changies to the coversion/create methds for Loadcases

