### PR TITLE
Deplay Fuzzy Matching for Standard Materials and Sections.

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Material/Material.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Material/Material.cs
@@ -42,12 +42,29 @@ namespace RFEM_Toolkit_Test.Elements
         IMaterialFragment concrete;
         IMaterialFragment steel;
 
-        NameOrDescriptionComparer comparer = new NameOrDescriptionComparer();
+        NameOrDescriptionComparer comparer; 
+
+
 
         [OneTimeSetUp]
-        public void InitializeRFEM6Adapter()
+        public void SetUpScenario()
         {
+
+            /***************************************************/
+            /**** Arrange                                   ****/
+            /***************************************************/
             adapter = new RFEM6Adapter(true);
+
+            comparer = new NameOrDescriptionComparer();
+
+            glulam = BH.Engine.Library.Query.Match("Glulam", "GL 20C", true, true) as IMaterialFragment;
+            steel = BH.Engine.Library.Query.Match("Steel", "S450", true, true) as IMaterialFragment;
+            concrete = BH.Engine.Library.Query.Match("Concrete", "C30/37", true, true) as Concrete;
+
+            timberC = BH.Engine.Library.Query.Match("SawnTimber", "C14", true, true) as IMaterialFragment;
+            timberT = BH.Engine.Library.Query.Match("SawnTimber", "T8", true, true) as IMaterialFragment;
+            timberD = BH.Engine.Library.Query.Match("SawnTimber", "D18", true, true) as IMaterialFragment;
+
         }
 
         [TearDown]
@@ -59,14 +76,70 @@ namespace RFEM_Toolkit_Test.Elements
         [Test]
         public void PushPullOFSteel()
         {
-            //TODO: Add a test for steel
+
+            /***************************************************/
+            /**** Act                                    ****/
+            /***************************************************/
+
+            //Push it once
+            adapter.Push(new List<IMaterialFragment>() { steel });
+            adapter.Push(new List<IMaterialFragment>() { steel.DeepClone() });
+
+
+            //Pull it   
+            FilterRequest materialFilter = new FilterRequest() { Type = typeof(IMaterialFragment) };
+            var materialPulled = adapter.Pull(materialFilter).ToList();
+            IMaterialFragment mp = (IMaterialFragment)materialPulled[0];
+
+
+            /***************************************************/
+            /**** Assertions                                ****/
+            /***************************************************/
+
+            //Null Check
+            Assert.IsNotNull(mp);
+
+            //Compares pushed to pulled material
+            Assert.IsTrue(comparer.Equals(steel, mp));
+
+            //Checks if only one material is pulled after double push
+            Assert.AreEqual(1, materialPulled.Count);
+
         }
 
 
         [Test]
         public void PushPullOFConcrete()
         {
-            //TODO: Add a test for concrete
+            /***************************************************/
+            /**** Act                                       ****/
+            /***************************************************/
+
+            //Push it once
+            adapter.Push(new List<IMaterialFragment>() { concrete });
+            adapter.Push(new List<IMaterialFragment>() { concrete.DeepClone() });
+
+
+            //Pull it   
+            FilterRequest materialFilter = new FilterRequest() { Type = typeof(IMaterialFragment) };
+            var materialPulled = adapter.Pull(materialFilter).ToList();
+            IMaterialFragment mp = (IMaterialFragment)materialPulled[0];
+
+
+
+            /***************************************************/
+            /**** Assertions                                ****/
+            /***************************************************/
+
+            //Null Check
+            Assert.IsNotNull(mp);
+
+            //Compares pushed to pulled material
+            Assert.IsTrue(comparer.Equals(concrete, mp));
+
+            //Checks if only one material is pulled after double push
+            Assert.AreEqual(1, materialPulled.Count);
+
 
         }
 
@@ -76,16 +149,15 @@ namespace RFEM_Toolkit_Test.Elements
         {
 
             /***************************************************/
-            /**** Test Preparation                          ****/
+            /**** Act                                       ****/
             /***************************************************/
 
-            //TODO: Add a test for Glulam
-            glulam = BH.Engine.Library.Query.Match("Glulam", "GL 20C", true, true).DeepClone() as IMaterialFragment;
 
-            //Push it once
-
+            //adapter.Push(new List<IMaterialFragment>() { steel });
+            //adapter.Push(new List<IMaterialFragment>() { concrete });
             adapter.Push(new List<IMaterialFragment>() { glulam });
-            adapter.Push(new List<IMaterialFragment>() { glulam.DeepClone()});
+            adapter.Push(new List<IMaterialFragment>() { glulam.DeepClone() });
+
 
             //Pull it   
             FilterRequest materialFilter = new FilterRequest() { Type = typeof(IMaterialFragment) };
@@ -103,7 +175,7 @@ namespace RFEM_Toolkit_Test.Elements
 
             //Compares pushed to pulled material
             Assert.IsTrue(comparer.Equals(glulam, mp));
-            
+
             //Checks if only one material is pulled after double push
             Assert.AreEqual(1, materialPulled.Count);
 
@@ -115,14 +187,8 @@ namespace RFEM_Toolkit_Test.Elements
         public void PushPullOFTimber()
         {
             /***************************************************/
-            /**** Test Preparation                          ****/
+            /**** Act                                       ****/
             /***************************************************/
-
-            //TODO: Add a test for Glulam
-            timberC = BH.Engine.Library.Query.Match("SawnTimber", "C14", true, true).DeepClone() as IMaterialFragment;
-            timberT = BH.Engine.Library.Query.Match("SawnTimber", "T8", true, true).DeepClone() as IMaterialFragment;
-            timberD = BH.Engine.Library.Query.Match("SawnTimber", "D18", true, true).DeepClone() as IMaterialFragment;
-
 
             //Push it once
 
@@ -136,7 +202,7 @@ namespace RFEM_Toolkit_Test.Elements
 
             //Pull it   
             FilterRequest materialFilter = new FilterRequest() { Type = typeof(IMaterialFragment) };
-            List<IMaterialFragment> materialPulled = adapter.Pull(materialFilter).ToList().Select(m=>(IMaterialFragment)m).ToList();
+            List<IMaterialFragment> materialPulled = adapter.Pull(materialFilter).ToList().Select(m => (IMaterialFragment)m).ToList();
             HashSet<IMaterialFragment> materialPulledSet = new HashSet<IMaterialFragment>(comparer);
             materialPulledSet.UnionWith(materialPulled);
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/SectionFuzzyMatching.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/SectionFuzzyMatching.cs
@@ -106,7 +106,7 @@ namespace RFEM_Toolkit_Test.Elements
             sectionList.AddRange(uk_Steel_Section);
             sectionList.AddRange(us_Steel_Section);
 
-            var sec = RFEM6Adapter.ReadStandardSteelSections(weirdStringName, sectionList);
+            //var sec = RFEM6Adapter.ReadStandardSteelSections(weirdStringName, sectionList);
 
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/SectionFuzzyMatching.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/SectionFuzzyMatching.cs
@@ -1,0 +1,126 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using BH.Adapter.RFEM6;
+using BH.Engine.Analytical;
+using BH.oM.Base;
+using BH.oM.Data.Requests;
+using BH.oM.Spatial.ShapeProfiles;
+using BH.oM.Structure.MaterialFragments;
+using BH.oM.Structure.SectionProperties;
+using Dlubal.WS.Rfem6.Model;
+
+namespace RFEM_Toolkit_Test.Elements
+{
+
+
+    public class SectionFuzzyMatching_Test
+
+    {
+        RFEM6Adapter adapter;
+        ISectionProperty steelSection1;
+        ISectionProperty steelSection2;
+        ISectionProperty concreteSection0;
+        ISectionProperty concreteSection1;
+        ISectionProperty genericSectionGLTimber;
+        ISectionProperty genericSectionSawnTimber;
+        IProfile rectProfileGLTimber;
+        IProfile circleProfileSawnTimber;
+        IProfile concreteProfile1;
+        IProfile concreteProfile2;
+
+        IMaterialFragment glulam;
+        IMaterialFragment timberC;
+        Concrete concrete0;
+        Concrete concrete1;
+
+        RFEMSectionComparer comparer;
+
+        [OneTimeSetUp]
+        public void InitializeRFEM6Adapter()
+        {
+            adapter = new RFEM6Adapter(true);
+            comparer = new RFEMSectionComparer();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            //adapter.Wipeout();
+        }
+
+        [Test]
+        public void PushPullOfSteelSection()
+        {
+            ///////////////////////////
+            var sectionLibrary = BH.Engine.Library.Query.Library("EU_SteelSections");
+            var k=sectionLibrary.Select(s=>s.Name).Select(k=>(string)k).ToList();
+            
+            var weirdStringName = "cHs-42.4X.32";
+            Dictionary<string, int> scorsDict= new Dictionary<string, int>();
+            k.ForEach(z=>scorsDict.Add(z,BH.Engine.Search.Compute.MatchScore(weirdStringName,z)));
+            
+            var scorsDictSorted = scorsDict.OrderByDescending(z=>z.Value).ToDictionary(z=>z.Key,z=>z.Value);
+            var sortedSectNames=scorsDictSorted.Keys.ToList();
+
+            var foundName= sortedSectNames[0];
+
+
+            /////////////////////////////
+            //var sectionLibrary0 = BH.Engine.Library.Query.Library("UK_SteelSections");
+            //var k0 = sectionLibrary.Select(s => s.Name).Select(k => (string)k).ToList();
+
+            //var weirdStringName0 = "cHs-42.4X.32";
+            //Dictionary<string, int> scorsDict0 = new Dictionary<string, int>();
+            //k.ForEach(z => scorsDict.Add(z, BH.Engine.Search.Compute.MatchScore(weirdStringName, z)));
+
+            //var scorsDictSorted0 = scorsDict.OrderByDescending(z => z.Value).ToDictionary(z => z.Key, z => z.Value);
+            //var sortedSectNames0 = scorsDictSorted.Keys.ToList();
+
+            //var foundName0 = sortedSectNames[0];
+
+            //Read Standard BHoM Steel Libraries
+            List<IBHoMObject> sectionList = new List<IBHoMObject>();
+            var eu_Steel_Section = BH.Engine.Library.Query.Library("EU_SteelSections");
+            var uk_Steel_Section = BH.Engine.Library.Query.Library("UK_SteelSections");
+            var us_Steel_Section = BH.Engine.Library.Query.Library("US_SteelSections");
+            sectionList.AddRange(eu_Steel_Section);
+            sectionList.AddRange(uk_Steel_Section);
+            sectionList.AddRange(us_Steel_Section);
+
+            var sec = RFEM6Adapter.ReadStandardSteelSections(weirdStringName, sectionList);
+
+        }
+
+        [Test]
+        public void PushPullOfConcreteSection()
+        {
+
+           
+
+
+        }
+
+       
+
+    }
+
+}

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/Section_Refactored.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/Section_Refactored.cs
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using BH.Adapter.RFEM6;
+using BH.Engine.Base;
+using BH.oM.Base;
+using BH.oM.Data.Requests;
+using BH.oM.Spatial.ShapeProfiles;
+using BH.oM.Structure.MaterialFragments;
+using BH.oM.Structure.SectionProperties;
+
+namespace RFEM_Toolkit_Test.Elements
+{
+
+
+    public class Section_Refactored_Test
+    {
+        RFEM6Adapter adapter;
+        ISectionProperty steelSection1;
+        ISectionProperty steelSection2;
+        ISectionProperty concreteSection0;
+        ISectionProperty concreteSection1;
+        ISectionProperty genericSectionGLTimber;
+        ISectionProperty genericSectionSawnTimber;
+        IProfile rectProfileGLTimber;
+        IProfile circleProfileSawnTimber;
+        IProfile concreteProfile1;
+        IProfile concreteProfile2;
+
+        IMaterialFragment glulam;
+        IMaterialFragment timberC;
+        Concrete concrete0;
+        Concrete concrete1;
+
+        RFEMSectionComparer comparer;
+
+        [OneTimeSetUp]
+        public void InitializeRFEM6Adapter()
+        {
+            adapter = new RFEM6Adapter(true);
+            comparer = new RFEMSectionComparer();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            //adapter.Wipeout();
+        }
+
+        [Test]
+        public void PullOfSection()
+        {
+            /***************************************************/
+            /**** Test Preparation                          ****/
+            /***************************************************/
+
+           
+            FilterRequest sectionFilter = new FilterRequest() { Type = typeof(ISectionProperty) };
+            var sectionsPulled = adapter.Pull(sectionFilter).Select(s => (ISectionProperty)s).ToList();
+            //HashSet<ISectionProperty> sectionPulledSet = new HashSet<ISectionProperty>(comparer);
+            //sectionPulledSet.UnionWith(sectionsPulled.ToHashSet());
+
+        }
+
+    }
+}

--- a/.ci/unit-tests/RFEM_Toolkit_Test/RFEM_Toolkit_Test.csproj
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/RFEM_Toolkit_Test.csproj
@@ -79,6 +79,12 @@
 			<HintPath>$(ProgramData)\BHoM\Assemblies\Physical_oM.dll</HintPath>
 			<SpecificVersion>false</SpecificVersion>
 		</Reference>
+		<Reference Include="Search_Engine">
+		  <HintPath>..\..\..\..\..\ProgramData\BHoM\Assemblies\Search_Engine.dll</HintPath>
+		</Reference>
+		<Reference Include="Search_oM">
+		  <HintPath>..\..\..\..\..\ProgramData\BHoM\Assemblies\Search_oM.dll</HintPath>
+		</Reference>
 		<Reference Include="Spatial_Engine">
 			<HintPath>$(ProgramData)\BHoM\Assemblies\Spatial_Engine.dll</HintPath>
 			<SpecificVersion>false</SpecificVersion>

--- a/.ci/unit-tests/RFEM_Toolkit_Test/RFEM_Toolkit_Test.csproj
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/RFEM_Toolkit_Test.csproj
@@ -80,10 +80,10 @@
 			<SpecificVersion>false</SpecificVersion>
 		</Reference>
 		<Reference Include="Search_Engine">
-		  <HintPath>..\..\..\..\..\ProgramData\BHoM\Assemblies\Search_Engine.dll</HintPath>
+			<HintPath>$(ProgramData)\BHoM\Assemblies\Search_Engine.dll</HintPath>
 		</Reference>
 		<Reference Include="Search_oM">
-		  <HintPath>..\..\..\..\..\ProgramData\BHoM\Assemblies\Search_oM.dll</HintPath>
+			<HintPath>$(ProgramData)\BHoM\Assemblies\Search_oM.dll</HintPath>
 		</Reference>
 		<Reference Include="Spatial_Engine">
 			<HintPath>$(ProgramData)\BHoM\Assemblies\Spatial_Engine.dll</HintPath>

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Geometry/Material.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Geometry/Material.cs
@@ -38,6 +38,7 @@ namespace BH.Adapter.RFEM6
         private bool CreateCollection(IEnumerable<IMaterialFragment> materialFragments)
         {
 
+
             foreach (IMaterialFragment bhMaterial in materialFragments)
             {
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Material.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Material.cs
@@ -38,6 +38,8 @@ namespace BH.Adapter.RFEM6
         private List<IMaterialFragment> ReadMaterial(List<string> ids = null)
         {
 
+            //var steelMaterialLibrary = BH.Engine.Library.Query.Library("Structure\\Materials");
+            List<IMaterialFragment> libraryMaterials = BH.Engine.Library.Query.Library("Structure\\Materials").Select(m => (IMaterialFragment)m).ToList();
             //Read all materials from RFEM
             List<IMaterialFragment> materialList = new List<IMaterialFragment>();
             rfModel.object_with_children[] materialsNumbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_MATERIAL);
@@ -50,8 +52,8 @@ namespace BH.Adapter.RFEM6
                 foreach (var rfMaterial in allMaterials)
                 {
                     //Conversion of material to BHoM material
-                    IMaterialFragment material = rfMaterial.FromRFEM();
-                    
+                    IMaterialFragment material = rfMaterial.FromRFEM(libraryMaterials);
+
                     if (material != null)
                     {
                         materialList.Add(material);
@@ -64,6 +66,7 @@ namespace BH.Adapter.RFEM6
 
             return materialList;
         }
+
 
     }
 }

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -34,107 +34,15 @@ using rfModel = Dlubal.WS.Rfem6.Model;
 using BH.Engine.Base;
 using BH.oM.Base;
 using System.Text.RegularExpressions;
+using System.Security.RightsManagement;
 
 namespace BH.Adapter.RFEM6
 {
     public partial class RFEM6Adapter
     {
 
-        //private List<ISectionProperty> ReadSectionProperties(List<string> ids = null)
-        //{
-
-        //    List<ISectionProperty> sectionList = new List<ISectionProperty>();
-
-        //    var sectionNumbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_SECTION);
-        //    var allSections = sectionNumbers.ToList().Select(n => m_Model.get_section(n.no));
-
-        //    Dictionary<int, IMaterialFragment> materials = this.GetCachedOrReadAsDictionary<int, IMaterialFragment>();
-        //    IMaterialFragment material;
-        //    var eu_Steel_Section = BH.Engine.Library.Query.Library("EU_SteelSections");
-        //    var uk_Steel_Section = BH.Engine.Library.Query.Library("UK_SteelSections");
-        //    var us_Steel_Section = BH.Engine.Library.Query.Library("US_SteelSections");
-
-
-        //    foreach (var section in allSections)
-        //    {
-
-        //        //String sectionName = (new string(section.name.Where(c => !char.IsWhiteSpace(c)).ToArray())).Split()[0];
-        //        String sectionName = new String((section.name.Where(c => !char.IsWhiteSpace(c)).ToArray())).Split()[0];
-        //        sectionName = sectionName.Split('|')[0];
-        //        ISectionProperty bhSetion;
-        //        //Standard steel sections
-        //        if (section.type.Equals(rfModel.section_type.TYPE_STANDARDIZED_STEEL))
-        //        {
-
-        //            //Checking differnt data sets for for sections
-
-        //            bhSetion = BH.Engine.Library.Query.Match("EU_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
-        //            if (bhSetion is null) {
-        //                bhSetion = BH.Engine.Library.Query.Match("UK_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
-        //            }
-        //            if (bhSetion is null) {
-        //                bhSetion = BH.Engine.Library.Query.Match("US_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
-        //            }
-
-        //            bhSetion.SetRFEM6ID(section.no);
-        //            sectionList.Add(bhSetion);
-
-        //        }
-        //        //Concrete Section Parametric Massive I
-        //        else if (section.type.Equals(rfModel.section_type.TYPE_PARAMETRIC_MASSIVE_I))
-        //        {
-
-        //            if (!materials.TryGetValue(section.material, out material))
-        //            {
-        //                material = m_Model.get_material(section.material).FromRFEM();
-        //                materials[section.material] = material;
-        //            }
-
-
-        //            if (material != null)
-        //            {
-
-        //                bhSetion = section.FromRFEM(material);
-        //                bhSetion.SetRFEM6ID(section.no);
-        //                sectionList.Add(bhSetion);
-
-        //            }
-
-        //        }
-        //        else if (section.type.Equals(rfModel.section_type.TYPE_STANDARDIZED_TIMBER))
-        //        {
-        //            if (!materials.TryGetValue(section.material, out material))
-        //            {
-        //                material = m_Model.get_material(section.material).FromRFEM();
-        //                materials[section.material] = material;
-        //            }
-
-
-        //            if (material != null)
-        //            {
-
-        //                bhSetion = section.FromRFEM(material);
-        //                bhSetion.SetRFEM6ID(section.no);
-        //                sectionList.Add(bhSetion);
-
-        //            }
-
-
-        //        }
-        //        else {
-
-
-        //        }
-
-
-        //        //IMaterialFragment material;
-
-        //    }
-
-        //    return sectionList;
-        //}
-
-        public static ISectionProperty ReadStandardSteelSections(string sectionName, List<IBHoMObject> bhSections)
+        // Method to read all section properties from RFEM6
+        private static ISectionProperty ReadStandardSteelSections(string sectionName, List<IBHoMObject> bhSections)
         {
 
             //sectionName = sectionName.Replace(" ", "");
@@ -193,15 +101,8 @@ namespace BH.Adapter.RFEM6
 
             }
 
-
             return (ISectionProperty)result;
 
-            //var scorsDictSorted = scorsDict.OrderByDescending(z => z.Value).ToDictionary(z => z.Key, z => z.Value);
-            //var sortedSectNames = scorsDictSorted.Keys.ToList();
-
-            //var matchedSection = sortedSectNames[0];
-
-            //return matchedSection;
 
         }
 
@@ -210,18 +111,17 @@ namespace BH.Adapter.RFEM6
         private List<ISectionProperty> ReadSectionProperties_refactor(List<string> ids = null)
         {
             List<ISectionProperty> sectionList = new List<ISectionProperty>();
+      
             //Read Standard BHoM Steel Libraries
             List<IBHoMObject> sectionListLib = new List<IBHoMObject>();
-            var eu_Steel_Section = BH.Engine.Library.Query.Library("EU_SteelSections");
-            var uk_Steel_Section = BH.Engine.Library.Query.Library("UK_SteelSections");
-            var us_Steel_Section = BH.Engine.Library.Query.Library("US_SteelSections");
-            sectionListLib.AddRange(eu_Steel_Section);
-            sectionListLib.AddRange(uk_Steel_Section);
-            sectionListLib.AddRange(us_Steel_Section);
+            //List<IMaterialFragment> matListLib = new List<IMaterialFragment>();
+      
+            sectionListLib = BH.Engine.Library.Query.Library("Structure\\SectionProperties");
+            //matListLib = BH.Engine.Library.Query.Library("Structure\\Materials").Select(m => (IMaterialFragment)m).ToList();
 
             // Read RFEM Material Fragments From Caching System
             Dictionary<int, IMaterialFragment> materials = this.GetCachedOrReadAsDictionary<int, IMaterialFragment>();
-            IMaterialFragment material;
+            IMaterialFragment sectionMaterials;
 
             // Read RFEM Sections from Model
             var sectionNumbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_SECTION);
@@ -251,47 +151,34 @@ namespace BH.Adapter.RFEM6
                 else if (section.type.Equals(rfModel.section_type.TYPE_PARAMETRIC_MASSIVE_I))
                 {
 
-                    if (!materials.TryGetValue(section.material, out material))
+                    if (!materials.TryGetValue(section.material, out sectionMaterials))
                     {
-                        material = m_Model.get_material(section.material).FromRFEM();
-                        materials[section.material] = material;
+                        continue;
                     }
 
-
-                    if (material != null)
-                    {
-
-                        bhSetion = section.FromRFEM(material);
-                        bhSetion.SetRFEM6ID(section.no);
-                        sectionList.Add(bhSetion);
-
-                    }
+                    bhSetion = section.FromRFEM(sectionMaterials);
+                    bhSetion.SetRFEM6ID(section.no);
+                    sectionList.Add(bhSetion);
 
                 }
                 // Standardized Timber Section
                 else if (section.type.Equals(rfModel.section_type.TYPE_STANDARDIZED_TIMBER))
                 {
-                    if (!materials.TryGetValue(section.material, out material))
+                    if (!materials.TryGetValue(section.material, out sectionMaterials))
                     {
-                        material = m_Model.get_material(section.material).FromRFEM();
-                        materials[section.material] = material;
+          
+                        continue;
                     }
 
 
-                    if (material != null)
+                    if (sectionMaterials != null)
                     {
 
-                        bhSetion = section.FromRFEM(material);
+                        bhSetion = section.FromRFEM(sectionMaterials);
                         bhSetion.SetRFEM6ID(section.no);
                         sectionList.Add(bhSetion);
 
                     }
-
-
-                }
-                else
-                {
-
 
 
                 }
@@ -305,7 +192,7 @@ namespace BH.Adapter.RFEM6
             return sectionList;
         }
 
-        private static bool IsAnagramUsingSort(string str1, string str2)
+        public static bool IsAnagramUsingSort(string str1, string str2)
         {
             if (str1.Length != str2.Length)
                 return false;

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -95,9 +95,7 @@ namespace BH.Adapter.RFEM6
                         break;
                     }
 
-
                 }
-
 
             }
 
@@ -111,11 +109,11 @@ namespace BH.Adapter.RFEM6
         private List<ISectionProperty> ReadSectionProperties_refactor(List<string> ids = null)
         {
             List<ISectionProperty> sectionList = new List<ISectionProperty>();
-      
+
             //Read Standard BHoM Steel Libraries
             List<IBHoMObject> sectionListLib = new List<IBHoMObject>();
             //List<IMaterialFragment> matListLib = new List<IMaterialFragment>();
-      
+
             sectionListLib = BH.Engine.Library.Query.Library("Structure\\SectionProperties");
             //matListLib = BH.Engine.Library.Query.Library("Structure\\Materials").Select(m => (IMaterialFragment)m).ToList();
 
@@ -135,16 +133,16 @@ namespace BH.Adapter.RFEM6
                 // Preprocessing RFEM6 Section Name to match with BHoM Library
                 String sectionName = new String((section.name.Where(c => !char.IsWhiteSpace(c)).ToArray())).Split()[0];
                 sectionName = sectionName.Split('|')[0];
-                ISectionProperty bhSetion;
+                ISectionProperty bhSection;
                 //Standard steel sections
                 if (section.type.Equals(rfModel.section_type.TYPE_STANDARDIZED_STEEL))
                 {
 
                     // Brows Through the BHoM Library and find the best match
-                    bhSetion = ReadStandardSteelSections(sectionName, sectionListLib);
+                    bhSection = ReadStandardSteelSections(sectionName, sectionListLib);
 
-                    bhSetion.SetRFEM6ID(section.no);
-                    sectionList.Add(bhSetion);
+                    bhSection.SetRFEM6ID(section.no);
+                    sectionList.Add(bhSection);
 
                 }
                 // Concrete Section Parametric Massive I
@@ -156,9 +154,10 @@ namespace BH.Adapter.RFEM6
                         continue;
                     }
 
-                    bhSetion = section.FromRFEM(sectionMaterials);
-                    bhSetion.SetRFEM6ID(section.no);
-                    sectionList.Add(bhSetion);
+                    //bhSection = section.FromRFEM(sectionMaterials);
+                    bhSection = section.FromRFEM_MassivI(sectionMaterials);
+                    bhSection.SetRFEM6ID(section.no);
+                    sectionList.Add(bhSection);
 
                 }
                 // Standardized Timber Section
@@ -166,7 +165,7 @@ namespace BH.Adapter.RFEM6
                 {
                     if (!materials.TryGetValue(section.material, out sectionMaterials))
                     {
-          
+
                         continue;
                     }
 
@@ -174,18 +173,27 @@ namespace BH.Adapter.RFEM6
                     if (sectionMaterials != null)
                     {
 
-                        bhSetion = section.FromRFEM(sectionMaterials);
-                        bhSetion.SetRFEM6ID(section.no);
-                        sectionList.Add(bhSetion);
+                        bhSection = section.FromRFEM(sectionMaterials);
+                        bhSection.SetRFEM6ID(section.no);
+                        sectionList.Add(bhSection);
 
                     }
 
-
                 }
 
+                else if (section.type.Equals(rfModel.section_type.TYPE_PARAMETRIC_THIN_WALLED))
+                {
 
+                    if (!materials.TryGetValue(section.material, out sectionMaterials))
+                    {
 
-                //IMaterialFragment material;
+                        continue;
+                    }
+                    bhSection = section.FromRFEM_ThinWalled(sectionMaterials);
+                    bhSection.SetRFEM6ID(section.no);
+                    sectionList.Add(bhSection);
+                }
+
 
             }
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -32,50 +32,222 @@ using BH.oM.Spatial.ShapeProfiles;
 
 using rfModel = Dlubal.WS.Rfem6.Model;
 using BH.Engine.Base;
+using BH.oM.Base;
+using System.Text.RegularExpressions;
 
 namespace BH.Adapter.RFEM6
 {
     public partial class RFEM6Adapter
     {
 
-        private List<ISectionProperty> ReadSectionProperties(List<string> ids = null)
+        //private List<ISectionProperty> ReadSectionProperties(List<string> ids = null)
+        //{
+
+        //    List<ISectionProperty> sectionList = new List<ISectionProperty>();
+
+        //    var sectionNumbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_SECTION);
+        //    var allSections = sectionNumbers.ToList().Select(n => m_Model.get_section(n.no));
+
+        //    Dictionary<int, IMaterialFragment> materials = this.GetCachedOrReadAsDictionary<int, IMaterialFragment>();
+        //    IMaterialFragment material;
+        //    var eu_Steel_Section = BH.Engine.Library.Query.Library("EU_SteelSections");
+        //    var uk_Steel_Section = BH.Engine.Library.Query.Library("UK_SteelSections");
+        //    var us_Steel_Section = BH.Engine.Library.Query.Library("US_SteelSections");
+
+
+        //    foreach (var section in allSections)
+        //    {
+
+        //        //String sectionName = (new string(section.name.Where(c => !char.IsWhiteSpace(c)).ToArray())).Split()[0];
+        //        String sectionName = new String((section.name.Where(c => !char.IsWhiteSpace(c)).ToArray())).Split()[0];
+        //        sectionName = sectionName.Split('|')[0];
+        //        ISectionProperty bhSetion;
+        //        //Standard steel sections
+        //        if (section.type.Equals(rfModel.section_type.TYPE_STANDARDIZED_STEEL))
+        //        {
+
+        //            //Checking differnt data sets for for sections
+
+        //            bhSetion = BH.Engine.Library.Query.Match("EU_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
+        //            if (bhSetion is null) {
+        //                bhSetion = BH.Engine.Library.Query.Match("UK_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
+        //            }
+        //            if (bhSetion is null) {
+        //                bhSetion = BH.Engine.Library.Query.Match("US_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
+        //            }
+
+        //            bhSetion.SetRFEM6ID(section.no);
+        //            sectionList.Add(bhSetion);
+
+        //        }
+        //        //Concrete Section Parametric Massive I
+        //        else if (section.type.Equals(rfModel.section_type.TYPE_PARAMETRIC_MASSIVE_I))
+        //        {
+
+        //            if (!materials.TryGetValue(section.material, out material))
+        //            {
+        //                material = m_Model.get_material(section.material).FromRFEM();
+        //                materials[section.material] = material;
+        //            }
+
+
+        //            if (material != null)
+        //            {
+
+        //                bhSetion = section.FromRFEM(material);
+        //                bhSetion.SetRFEM6ID(section.no);
+        //                sectionList.Add(bhSetion);
+
+        //            }
+
+        //        }
+        //        else if (section.type.Equals(rfModel.section_type.TYPE_STANDARDIZED_TIMBER))
+        //        {
+        //            if (!materials.TryGetValue(section.material, out material))
+        //            {
+        //                material = m_Model.get_material(section.material).FromRFEM();
+        //                materials[section.material] = material;
+        //            }
+
+
+        //            if (material != null)
+        //            {
+
+        //                bhSetion = section.FromRFEM(material);
+        //                bhSetion.SetRFEM6ID(section.no);
+        //                sectionList.Add(bhSetion);
+
+        //            }
+
+
+        //        }
+        //        else {
+
+
+        //        }
+
+
+        //        //IMaterialFragment material;
+
+        //    }
+
+        //    return sectionList;
+        //}
+
+        public static ISectionProperty ReadStandardSteelSections(string sectionName, List<IBHoMObject> bhSections)
         {
 
-            List<ISectionProperty> sectionList = new List<ISectionProperty>();
+            //sectionName = sectionName.Replace(" ", "");
+            sectionName = Regex.Replace(sectionName, @"[^a-zA-Z0-9]", "");
 
+            Dictionary<ISectionProperty, int> scorsDict = new Dictionary<ISectionProperty, int>();
+            bhSections.ForEach(z => scorsDict.Add((ISectionProperty)z, BH.Engine.Search.Compute.MatchScore(sectionName, Regex.Replace(z.Name, @"[^a-zA-Z0-9]", ""))));
+
+            Dictionary<int, HashSet<IBHoMObject>> scorsDict_test = new Dictionary<int, HashSet<IBHoMObject>>();
+            //bhSections.ForEach(z => scorsDict_test[BH.Engine.Search.Compute.MatchScore(sectionName, Regex.Replace(z.Name, @"[^a-zA-Z0-9]", "")], )));
+
+
+            foreach (var z in bhSections)
+            {
+
+                HashSet<IBHoMObject> value;
+                int key = BH.Engine.Search.Compute.MatchScore(sectionName, Regex.Replace(z.Name, @"[^a-zA-Z0-9]", ""));
+                if (scorsDict_test.TryGetValue(key, out value))
+                {
+                    scorsDict_test[key].Add((ISectionProperty)z);
+
+                }
+                else
+                {
+
+                    scorsDict_test[key] = new HashSet<IBHoMObject>() { z };
+                }
+
+
+            }
+            var sortedSectNames_test = scorsDict_test.OrderByDescending(z => z.Key).ToDictionary(z => z.Key, z => z.Value);
+
+            var result = sortedSectNames_test.Values.First().ToList()[0];
+
+            if (sortedSectNames_test.Values.First().Count > 1)
+            {
+                result = sortedSectNames_test.Values.First().ToList()[0];
+
+                foreach (var i in sortedSectNames_test.Values.First())
+                {
+
+                    string mod_name = Regex.Replace(i.Name, @"[^a-zA-Z0-9]", "");
+                    string mod_sectionName = Regex.Replace(sectionName, @"[^a-zA-Z0-9]", "");
+
+                    if (IsAnagramUsingSort(mod_name, mod_sectionName))
+                    {
+
+                        result = i;
+
+                        break;
+                    }
+
+
+                }
+
+
+            }
+
+
+            return (ISectionProperty)result;
+
+            //var scorsDictSorted = scorsDict.OrderByDescending(z => z.Value).ToDictionary(z => z.Key, z => z.Value);
+            //var sortedSectNames = scorsDictSorted.Keys.ToList();
+
+            //var matchedSection = sortedSectNames[0];
+
+            //return matchedSection;
+
+        }
+
+
+
+        private List<ISectionProperty> ReadSectionProperties_refactor(List<string> ids = null)
+        {
+            List<ISectionProperty> sectionList = new List<ISectionProperty>();
+            //Read Standard BHoM Steel Libraries
+            List<IBHoMObject> sectionListLib = new List<IBHoMObject>();
+            var eu_Steel_Section = BH.Engine.Library.Query.Library("EU_SteelSections");
+            var uk_Steel_Section = BH.Engine.Library.Query.Library("UK_SteelSections");
+            var us_Steel_Section = BH.Engine.Library.Query.Library("US_SteelSections");
+            sectionListLib.AddRange(eu_Steel_Section);
+            sectionListLib.AddRange(uk_Steel_Section);
+            sectionListLib.AddRange(us_Steel_Section);
+
+            // Read RFEM Material Fragments From Caching System
+            Dictionary<int, IMaterialFragment> materials = this.GetCachedOrReadAsDictionary<int, IMaterialFragment>();
+            IMaterialFragment material;
+
+            // Read RFEM Sections from Model
             var sectionNumbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_SECTION);
             var allSections = sectionNumbers.ToList().Select(n => m_Model.get_section(n.no));
 
-            Dictionary<int, IMaterialFragment> materials = this.GetCachedOrReadAsDictionary<int, IMaterialFragment>();
-            IMaterialFragment material;
+
 
             foreach (var section in allSections)
             {
 
-                //String sectionName = (new string(section.name.Where(c => !char.IsWhiteSpace(c)).ToArray())).Split()[0];
+                // Preprocessing RFEM6 Section Name to match with BHoM Library
                 String sectionName = new String((section.name.Where(c => !char.IsWhiteSpace(c)).ToArray())).Split()[0];
-                sectionName=sectionName.Split('|')[0];
+                sectionName = sectionName.Split('|')[0];
                 ISectionProperty bhSetion;
                 //Standard steel sections
                 if (section.type.Equals(rfModel.section_type.TYPE_STANDARDIZED_STEEL))
                 {
 
-                    //Checking differnt data sets for for sections
-
-                    bhSetion = BH.Engine.Library.Query.Match("EU_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
-                    if (bhSetion is null) {
-                        bhSetion = BH.Engine.Library.Query.Match("UK_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
-                    }
-                    if(bhSetion is null) {
-                        bhSetion = BH.Engine.Library.Query.Match("US_SteelSections", sectionName, true, true).DeepClone() as SteelSection;
-                    }
+                    // Brows Through the BHoM Library and find the best match
+                    bhSetion = ReadStandardSteelSections(sectionName, sectionListLib);
 
                     bhSetion.SetRFEM6ID(section.no);
                     sectionList.Add(bhSetion);
 
-
                 }
-                //Concrete Section Parametric Massive I
+                // Concrete Section Parametric Massive I
                 else if (section.type.Equals(rfModel.section_type.TYPE_PARAMETRIC_MASSIVE_I))
                 {
 
@@ -96,6 +268,7 @@ namespace BH.Adapter.RFEM6
                     }
 
                 }
+                // Standardized Timber Section
                 else if (section.type.Equals(rfModel.section_type.TYPE_STANDARDIZED_TIMBER))
                 {
                     if (!materials.TryGetValue(section.material, out material))
@@ -116,21 +289,35 @@ namespace BH.Adapter.RFEM6
 
 
                 }
-                else { 
-                
+                else
+                {
+
 
 
                 }
 
 
-                
+
                 //IMaterialFragment material;
-                
+
             }
 
             return sectionList;
         }
 
+        private static bool IsAnagramUsingSort(string str1, string str2)
+        {
+            if (str1.Length != str2.Length)
+                return false;
+
+            char[] sorted1 = str1.ToCharArray();
+            char[] sorted2 = str2.ToCharArray();
+
+            Array.Sort(sorted1);
+            Array.Sort(sorted2);
+
+            return sorted1.SequenceEqual(sorted2);
+        }
     }
 }
 

--- a/RFEM6_Adapter/CRUD/Read/_IRead.cs
+++ b/RFEM6_Adapter/CRUD/Read/_IRead.cs
@@ -62,7 +62,7 @@ namespace BH.Adapter.RFEM6
                 else if (type == typeof(RFEMHinge))
                     return ReadRFEMHinges(ids as dynamic);
                 else if (type == typeof(ISectionProperty) || type.GetInterfaces().Contains(typeof(ISectionProperty)))
-                    return ReadSectionProperties_refactor(ids as dynamic);
+                    return ReadSectionProperties(ids as dynamic);
                 else if (type == typeof(IMaterialFragment) || type.GetInterfaces().Contains(typeof(IMaterialFragment)))
                     return ReadMaterial(ids as dynamic);
                 else if (type == typeof(Line) || type == typeof(RFEMLine))

--- a/RFEM6_Adapter/CRUD/Read/_IRead.cs
+++ b/RFEM6_Adapter/CRUD/Read/_IRead.cs
@@ -62,7 +62,7 @@ namespace BH.Adapter.RFEM6
                 else if (type == typeof(RFEMHinge))
                     return ReadRFEMHinges(ids as dynamic);
                 else if (type == typeof(ISectionProperty) || type.GetInterfaces().Contains(typeof(ISectionProperty)))
-                    return ReadSectionProperties(ids as dynamic);
+                    return ReadSectionProperties_refactor(ids as dynamic);
                 else if (type == typeof(IMaterialFragment) || type.GetInterfaces().Contains(typeof(IMaterialFragment)))
                     return ReadMaterial(ids as dynamic);
                 else if (type == typeof(Line) || type == typeof(RFEMLine))

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Bar.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Bar.cs
@@ -42,7 +42,13 @@ namespace BH.Adapter.RFEM6
 
 
             Bar bar = new Bar { Start = node0, End = node1, SectionProperty = section, Name = "member nr." + member.no, FEAType = member.type.FromRFEM() };
-            BH.Engine.Base.Modify.SetPropertyValue(bar, "Comment", member.comment);
+
+            // If Comment has been added to Bar comment will be added as additinal property.
+            if (member.comment.Count() != 0)
+            {
+                BH.Engine.Base.Modify.SetPropertyValue(bar, "Comment", member.comment);
+            }
+            
             bar.SetRFEM6ID(member.no);
             return bar;
         }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Node.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Node.cs
@@ -44,7 +44,11 @@ namespace BH.Adapter.RFEM6
 
             bhNode.Name = "Node Nr. " + node.no;
             bhNode.SetRFEM6ID(node.no);
-            BH.Engine.Base.Modify.SetPropertyValue(bhNode, "Comment", node.comment);
+
+            if (node.comment.Count() != 0)
+            {
+                BH.Engine.Base.Modify.SetPropertyValue(bhNode, "Comment", node.comment);
+            }
             return bhNode;
         }
 

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Opening.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Opening.cs
@@ -55,7 +55,7 @@ namespace BH.Adapter.RFEM6
 
             List<Edge> edges = new List<Edge>();
             rfOpening.boundary_lines.ToList().ForEach(l => edges.Add(edgeDict[l]));
-            Opening o = new Opening() {Edges=edges};
+            Opening o = new Opening() { Edges = edges };
 
             opening.SetRFEM6ID(rfOpening.no);
             o.SetRFEM6ID(rfOpening.no);
@@ -64,7 +64,11 @@ namespace BH.Adapter.RFEM6
             RFEMOpening rfemOpening = new RFEMOpening() { Opening = o, SurfaceIDs = surfaceIDs };
 
             rfemOpening.SetRFEM6ID(rfOpening.no);
-            BH.Engine.Base.Modify.SetPropertyValue(rfemOpening, "Comment", rfOpening.comment);
+
+            if (rfOpening.comment.Count() != 0)
+            {
+                BH.Engine.Base.Modify.SetPropertyValue(rfemOpening, "Comment", rfOpening.comment);
+            }
             return rfemOpening;
 
         }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Panel.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Panel.cs
@@ -55,7 +55,7 @@ namespace BH.Adapter.RFEM6
             Panel panel = new Panel();
 
 
-            if (openingIDs.Count>0)
+            if (openingIDs.Count > 0)
             {
 
                 List<Opening> openingins = new List<Opening>();
@@ -81,8 +81,11 @@ namespace BH.Adapter.RFEM6
             }
 
             panel.SetRFEM6ID(rfSurface.no);
-            BH.Engine.Base.Modify.SetPropertyValue(panel, "Comment", rfSurface.comment);
 
+            if (rfSurface.comment.Count() != 0)
+            {
+                BH.Engine.Base.Modify.SetPropertyValue(panel, "Comment", rfSurface.comment);
+            }
             return panel;
         }
 

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -480,24 +480,80 @@ namespace BH.Adapter.RFEM6
         {
             section_parametrization_type parametrization_type = rfSection.parametrization_type;
 
-            var s = parametrization_type;
+            ISectionProperty resultSection = new ExplicitSection() { };
 
             switch (parametrization_type)
             {
+                case section_parametrization_type.PARAMETRIC_THIN_WALLED__SQUARE_HOLLOW_SECTION__SHS:
+
+                    if (rfSection.manufacturing_type.Equals(section_manufacturing_type.MANUFACTURING_TYPE_WELDED))
+                    {
+                        //welded
+                        resultSection = BH.Engine.Structure.Create.FabricatedSteelBoxSection(rfSection.h, rfSection.b, rfSection.t, rfSection.t, 0, sectionMaterials as Steel, rfSection.name);
+                    }
+                    else
+                    {
+                        //cold formed or hot rolled
+                        resultSection = BH.Engine.Structure.Create.SteelBoxSection(rfSection.h, rfSection.b, rfSection.t, rfSection.r_i, rfSection.r_o, sectionMaterials as Steel, rfSection.name);
+                    }
+
+                    break;
+                case section_parametrization_type.PARAMETRIC_THIN_WALLED__RECTANGULAR_HOLLOW_SECTION__RHS:
+
+                    if (rfSection.manufacturing_type.Equals(section_manufacturing_type.MANUFACTURING_TYPE_WELDED))
+                    {
+                        //welded
+                        resultSection = BH.Engine.Structure.Create.FabricatedSteelBoxSection(rfSection.h, rfSection.b, rfSection.t, rfSection.t, 0, sectionMaterials as Steel, rfSection.name);
+                    }
+                    else
+                    {
+                        //cold formed or hot rolled
+                        resultSection = BH.Engine.Structure.Create.SteelBoxSection(rfSection.h, rfSection.b, rfSection.t, rfSection.r_i, rfSection.r_o, sectionMaterials as Steel, rfSection.name);
+                    }
+
+                    break;
+                case section_parametrization_type.PARAMETRIC_THIN_WALLED__CIRCULAR_HOLLOW_SECTION__CHS:
+
+
+                    //cold formed or hot rolled
+                    resultSection = BH.Engine.Structure.Create.SteelTubeSection(rfSection.d, rfSection.t, sectionMaterials as Steel, rfSection.name);
+
+                    break;
                 case section_parametrization_type.PARAMETRIC_THIN_WALLED__I_SECTION__I:
 
-                    //BHoM ISection
+                    if (rfSection.manufacturing_type.Equals(section_manufacturing_type.MANUFACTURING_TYPE_WELDED))
+                    {
+                        //welded 
+                        resultSection = BH.Engine.Structure.Create.SteelFabricatedISection(rfSection.h, rfSection.t_w, rfSection.b, rfSection.t_f, rfSection.b, rfSection.t_f, rfSection.a_weld, sectionMaterials as Steel, rfSection.name);
+                    }
+                    else
+                    {
+                        //Hot rolled
+                        resultSection = BH.Engine.Structure.Create.SteelISection(rfSection.h, rfSection.t_w, rfSection.b, rfSection.t_f, rfSection.r_1, rfSection.r_2, sectionMaterials as Steel, rfSection.name);
+                    }
 
-                    return null;
+                    break;
+                case section_parametrization_type.PARAMETRIC_THIN_WALLED__T_SECTION__T:
+
+                    // welded
+                    if (rfSection.manufacturing_type.Equals(section_manufacturing_type.MANUFACTURING_TYPE_WELDED))
+                    {
+                        BH.Engine.Base.Compute.RecordWarning($"BHoM does not support welded T section. {rfSection.name} will be read as Hot Rolled.");
+                    }
+                    //Hot rolled
+                    resultSection = BH.Engine.Structure.Create.SteelTSection(rfSection.h, rfSection.t_w, rfSection.b, rfSection.t_f, rfSection.r_1, rfSection.r_2, sectionMaterials as Steel, rfSection.name);
+
+
+                    break;
                 default:
+
+                    BH.Engine.Base.Compute.RecordWarning($"Section {rfSection.name} could not be read and will be set to Explicite parameters set to 0!");
+                    resultSection = new ExplicitSection() { Name = rfSection.name };
                     break;
             }
 
 
-
-            return null;
-
-
+            return resultSection;
 
         }
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -56,7 +56,6 @@ namespace BH.Adapter.RFEM6
             }
 
 
-
             rfSection = new rfModel.section
             {
                 no = secNo,
@@ -120,6 +119,7 @@ namespace BH.Adapter.RFEM6
             int secNo = bhSection.GetRFEM6ID();
             Object bhComment = "";
 
+            // Check if Comment has been added to the section
             if (bhSection.CustomData.Count != 0)
             {
                 bhSection.CustomData.TryGetValue("Comment", out bhComment);

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -318,7 +318,9 @@ namespace BH.Adapter.RFEM6
                             v4 = ((bhSection as SteelSection).SectionProfile as BH.oM.Spatial.ShapeProfiles.TSectionProfile).RootRadius;
                             v5 = ((bhSection as SteelSection).SectionProfile as BH.oM.Spatial.ShapeProfiles.TSectionProfile).ToeRadius;
 
-                            rfSectionTypeName = "T " + v0 + "/" + v1 + "/" + v2 + "/" + v3 + "/" + v4 + "/" + v5 + "/H";
+                            //rfSectionTypeName = "T " + v0 + "/" + v1 + "/" + v2 + "/" + v3 + "/" + v4 + "/" + v5 + "/H";
+                            rfSectionTypeName = $"T {v0}/{v1}/{v2}/{v3}/{v4}/{v5}/H";
+
 
                             break;
                         case "Tube":

--- a/RFEM6_Adapter/RFEM6_Adapter.csproj
+++ b/RFEM6_Adapter/RFEM6_Adapter.csproj
@@ -93,6 +93,12 @@
 		<Reference Include="RFEMWebServiceLibrary">
 			<HintPath>..\packages\BHoM.Interop.RFEM6\RFEMWebServiceLibrary.dll</HintPath>
 		</Reference>
+		<Reference Include="Search_Engine">
+		  <HintPath>..\..\..\ProgramData\BHoM\Assemblies\Search_Engine.dll</HintPath>
+		</Reference>
+		<Reference Include="Search_oM">
+		  <HintPath>..\..\..\ProgramData\BHoM\Assemblies\Search_oM.dll</HintPath>
+		</Reference>
 		<Reference Include="Spatial_Engine">
 			<HintPath>$(ProgramData)\BHoM\Assemblies\Spatial_Engine.dll</HintPath>
 			<SpecificVersion>false</SpecificVersion>

--- a/RFEM6_Adapter/RFEM6_Adapter.csproj
+++ b/RFEM6_Adapter/RFEM6_Adapter.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net48</TargetFrameworks>
-	<AssemblyVersion>7.0.0.0</AssemblyVersion>
-	<Description>https://github.com/BHoM/RFEM6_Toolkit</Description>
-    <AssemblyName>RFEM6_Adapter</AssemblyName>
-    <RootNamespace>BH.Adapter.RFEM6</RootNamespace>
-	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-	<FileVersion>7.2.0.0</FileVersion>
-	<BaseOutputPath>..\Build\</BaseOutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net48</TargetFrameworks>
+		<AssemblyVersion>7.0.0.0</AssemblyVersion>
+		<Description>https://github.com/BHoM/RFEM6_Toolkit</Description>
+		<AssemblyName>RFEM6_Adapter</AssemblyName>
+		<RootNamespace>BH.Adapter.RFEM6</RootNamespace>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<FileVersion>7.2.0.0</FileVersion>
+		<BaseOutputPath>..\Build\</BaseOutputPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="CRUD\Update\Node - Copy.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="CRUD\Update\Node - Copy.cs" />
+	</ItemGroup>
 
 
 	<ItemGroup>
@@ -94,10 +94,10 @@
 			<HintPath>..\packages\BHoM.Interop.RFEM6\RFEMWebServiceLibrary.dll</HintPath>
 		</Reference>
 		<Reference Include="Search_Engine">
-		  <HintPath>..\..\..\ProgramData\BHoM\Assemblies\Search_Engine.dll</HintPath>
+			<HintPath>$(ProgramData)\BHoM\Assemblies\Search_Engine.dll</HintPath>
 		</Reference>
 		<Reference Include="Search_oM">
-		  <HintPath>..\..\..\ProgramData\BHoM\Assemblies\Search_oM.dll</HintPath>
+			<HintPath>$(ProgramData)\BHoM\Assemblies\Search_oM.dll</HintPath>
 		</Reference>
 		<Reference Include="Spatial_Engine">
 			<HintPath>$(ProgramData)\BHoM\Assemblies\Spatial_Engine.dll</HintPath>
@@ -127,11 +127,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Folder Include="Convert\ToRFEM6\BHoMDataStructure\Constraints\" />
+		<Folder Include="Convert\ToRFEM6\BHoMDataStructure\Constraints\" />
 	</ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-	  <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)RFEMWebServiceLibrary.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
-  </Target>
+	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)RFEMWebServiceLibrary.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
+	</Target>
 
 </Project>


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Pulling of sections and Materials does often cause issues. This issue could be avoided or mitigated by debloying fuzzy matching and enabeling pull of a default Section or material.

Closes #79 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Refactoring of the Conversion Methods FromRFEM for material and Sections. 
- Sections has been Split by RFEM Sections Type 'Standard', 'Thin Walled', 'Massive' and 'Timber'

### Additional comments
<!-- As required -->

- If Sections cant be read, as the section is not part of the BHoM Section or Material Data Set a default object will be generated. For sections this is e.g. an ExplicitSection. 
- Only rectangulare Timber Sections can be read from RFEM. 

