### PR TITLE
Error when pulling section from RFEM6 when multiple equal materials are present in a RFEM6 Modell

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Panel.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStrctures_Temporary/Panel.cs
@@ -22,6 +22,7 @@
 using BH.Adapter.RFEM6;
 using BH.Engine.Base;
 using BH.Engine.Geometry;
+using BH.Engine.Structure;
 using BH.oM.Analytical.Elements;
 using BH.oM.Data.Requests;
 using BH.oM.Geometry;
@@ -68,34 +69,16 @@ namespace RFEM_Toolkit_Test.Elements
         //}
 
         [Test]
-        public void pushTwoAdjecentPanels()
+        public void PullOfMaterial()
         {
-      
-            //var concrete = BH.Engine.Library.Query.Match("Concrete", "C25/30", true, true) as IMaterialFragment;
-            //var steel = BH.Engine.Library.Query.Match("Steel", "S235", true, true) as IMaterialFragment;
-
-            //panel1 = new Panel() { ExternalEdges = new List<Edge>() { edge4, edge5, edge6, edge7 }, Openings = new List<Opening>() { opening1 }, Property = new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.5, Material = concrete } };
-
-            //Polyline outline0 = new Polyline() { ControlPoints = new List<Point>() { new Point() { X = 0, Y = 0, Z = 0 }, new Point() { X = 10, Y = 0, Z = 0 }, new Point() { X = 10, Y = 10, Z = 0 }, new Point() { X = 0, Y = 10, Z = 0 } } };
-            //panel1 = BH.Engine.Structure.Create.Panel((ICurve)outline0.Close(), null, new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.1, Material = concrete }, "");
-
-            //Polyline outline1 = new Polyline() { ControlPoints = new List<Point>() { new Point() { X = 10, Y = 0, Z = 0 }, new Point() { X = 20, Y = 0, Z = 0 }, new Point() { X = 20, Y = 10, Z = 0 }, new Point() { X = 10, Y = 10, Z = 0 } } };
-            //panel2 = BH.Engine.Structure.Create.Panel((ICurve)outline1.Close().Flip(), null, new BH.oM.Structure.SurfaceProperties.ConstantThickness() { Thickness = 0.1, Material = concrete }, "");
 
 
-            //// Push panel 
-            //adapter.Push(new List<Panel>() { panel1, panel2 });
+            //Pull it
+            FilterRequest materialFilter = new FilterRequest() { Type = typeof(ISectionProperty) };
+            var materialPulled = adapter.Pull(materialFilter).ToList();
+            ISectionProperty mp = (ISectionProperty)materialPulled[0];
 
-            //// Pull it
-            //FilterRequest panelFilter = new FilterRequest() { Type = typeof(Panel) };
-            //var panelPulled = adapter.Pull(panelFilter).ToList();
-            //Panel pp = (Panel)panelPulled[0];
-
-            //// Check
-            //Assert.IsNotNull(pp);
-            //Assert.IsTrue(comparer.Equals(pp, panel1));
         }
-
 
     }
 }

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Material.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Material.cs
@@ -56,6 +56,7 @@ namespace BH.Adapter.RFEM6
 
                     if (material != null)
                     {
+                        material.SetRFEM6ID(rfMaterial.no);
                         materialList.Add(material);
 
                     }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Material.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Material.cs
@@ -92,7 +92,6 @@ namespace BH.Adapter.RFEM6
                 }
             }
 
-            result.SetRFEM6ID(rfMaterial.no);
 
             // If Material match is below 80 the assumption is that the is no matchi in libaray and default material will begreated
             if (sortedMatchingScoreDict.Keys.First() < 80)
@@ -107,6 +106,9 @@ namespace BH.Adapter.RFEM6
                 BH.Engine.Base.Compute.RecordWarning($"It is likely that the RFEM6 material {result.Name} has not corresponding element in the BHoM data set. It will be set to {result} instead when reading it, as this is the best guess.");
             }
 
+            result=result.DeepClone();
+            result.SetRFEM6ID(rfMaterial.no);
+            
             return (IMaterialFragment)result;
         }
 

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/SectionProperties.cs
@@ -269,6 +269,7 @@ namespace BH.Adapter.RFEM6
             }
 
             // Set Correct Materials
+            result=result.DeepClone();
             ((ISectionProperty)result).Material = sectionMaterials;
 
             return (ISectionProperty)result;

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -123,7 +123,7 @@ namespace BH.Adapter.RFEM6
         {
             get
             {
-                BasicHttpBinding binding = new BasicHttpBinding { SendTimeout = new TimeSpan(0, 0, 180), UseDefaultWebProxy = true, };
+                BasicHttpBinding binding = new BasicHttpBinding { SendTimeout = new TimeSpan(0, 0, 180), UseDefaultWebProxy = true,MaxReceivedMessageSize= 2147483647 };
                 return binding;
             }
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
When pulling a section from an RFEM6 model that has multiple equal materials defined, there seems to be an issue related to RFEM6ID distribution. However, I believe this PR will resolve the issue and allow section pulls in this specific case.

The proposed changes aim to enhance the overall distribution process and improve the efficiency of handling RFEM6ID. By implementing these adjustments, we can ensure smoother section pulls and avoid any potential issues.

Closes #83 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[test files](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/RFEM6_Tookit/Test/RFEM6_Toolkit-%2383-ErrorWhenPullingSectionFromRFEM6WhenMultipleEqualMaterialsArePresentInRFEM6?csf=1&web=1&e=sioZqP)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Create DeepClone when Converting Material
- Create DeepClone when Converting Section

### Additional comments
<!-- As required -->
