### PR TITLE
Load Push Results In Error

### DIFF
--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -70,7 +70,7 @@ namespace BH.Adapter.RFEM6
                     var currrSurfaceIds = (bhLoad as AreaUniformlyDistributedLoad).Objects.Elements.ToList().Select(e => m_PanelIDdict[e as Panel]).ToArray();
                     rfemAreaLoad.surfaces = currrSurfaceIds;
                     //rfemAreaLoad. = currrSurfaceIds;
-                    m_Model.set_surface_load(bhLoad.Loadcase.GetRFEM6ID(), rfemAreaLoad);
+                    m_Model.set_surface_load(bhLoad.Loadcase.Number, rfemAreaLoad);
 
                     continue;
                 }
@@ -106,7 +106,7 @@ namespace BH.Adapter.RFEM6
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
                     member_load member_load = (bhLoad as BarUniformlyDistributedLoad).ToRFEM6((member_load_load_type)nodalLoadType, id);
                     var rfMemberLoad = member_load;
-                    m_Model.set_member_load(bhLoad.Loadcase.GetRFEM6ID(), rfMemberLoad);
+                    m_Model.set_member_load(bhLoad.Loadcase.Number, rfMemberLoad);
                     continue;
                 }
 
@@ -116,7 +116,7 @@ namespace BH.Adapter.RFEM6
                     UpdateLoadIdDictionary(bhLoad);
                     int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
                     nodal_load rfPointLoad = (bhLoad as PointLoad).ToRFEM6((nodal_load_load_type)nodalLoadType, id);
-                    m_Model.set_nodal_load(bhLoad.Loadcase.GetRFEM6ID(), rfPointLoad);
+                    m_Model.set_nodal_load(bhLoad.Loadcase.Number, rfPointLoad);
                     continue;
 
                 }
@@ -156,7 +156,7 @@ namespace BH.Adapter.RFEM6
                             int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name + "_NonFreeLineLoad"];
                             var locatedEdte = edgeProsepectSet.Where(e => (edgeComparer).Equals(e, new Edge() { Curve = (bhLoad as GeometricalLineLoad).Location })).FirstOrDefault();
                             line_load rfLineLoad = (bhLoad as GeometricalLineLoad).ToRFEM6(id, locatedEdte.GetRFEM6ID(), (line_load_load_type)MomentOfForceLoad(bhLoad));
-                            m_Model.set_line_load(bhLoad.Loadcase.GetRFEM6ID(), rfLineLoad);
+                            m_Model.set_line_load(bhLoad.Loadcase.Number, rfLineLoad);
                             continue;
                         }
                         else
@@ -203,7 +203,7 @@ namespace BH.Adapter.RFEM6
                         // 
                         int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name + "_FreeLineLoad"];
                         free_line_load rfFreeLineLoad = (bhLoad as GeometricalLineLoad).ToRFEM6(id, currrSurfaceIds);
-                        m_Model.set_free_line_load(bhLoad.Loadcase.GetRFEM6ID(), rfFreeLineLoad);
+                        m_Model.set_free_line_load(bhLoad.Loadcase.Number, rfFreeLineLoad);
                         continue;
                     }
 

--- a/RFEM6_Adapter/CRUD/Delete/_IDelete.cs
+++ b/RFEM6_Adapter/CRUD/Delete/_IDelete.cs
@@ -43,6 +43,10 @@ namespace BH.Adapter.RFEM6
 
             if (!rfemType.HasValue)
             {
+                //Avoind warking when type is edge
+                if (type.Name == "Edge") { return 0; }
+
+                // Log a warning if the type is not supported
                 BH.Engine.Base.Compute.RecordWarning($"Delete not implemented for obejcts of type {type.Name}.");
                 return 0;
             }

--- a/RFEM6_Adapter/CRUD/NextId/NextId.cs
+++ b/RFEM6_Adapter/CRUD/NextId/NextId.cs
@@ -62,10 +62,10 @@ namespace BH.Adapter.RFEM6
 
                 int id = 0;
 
-                if (objectType.Name.Equals("PointLoad")|| objectType.Name.Equals("BarUniformlyDistributedLoad")|| objectType.Name.Equals("GeometricalLineLoad")|| objectType.Name.Equals("AreaUniformlyDistributedLoad"))
+                if (objectType.Name.Equals("PointLoad") || objectType.Name.Equals("BarUniformlyDistributedLoad") || objectType.Name.Equals("GeometricalLineLoad") || objectType.Name.Equals("AreaUniformlyDistributedLoad"))
                 {
-
-                   id = m_Model.get_first_free_number(rfType.Value, 1);
+                        
+                    id = 0;
 
                 }
                 else

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -38,233 +38,254 @@ using BH.Engine.Base;
 
 namespace BH.Adapter.RFEM6
 {
-    public partial class RFEM6Adapter
-    {
+	public partial class RFEM6Adapter
+	{
 
 
-        private List<ILoad> ReadBarLoad(List<string> ids = null)
-        {
-            //Find all possible Load cases
-            Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
-            List<int> loadCaseIds = loadCaseMap.Keys.ToList();
-            Dictionary<int, Bar> memberMap = this.GetCachedOrReadAsDictionary<int, Bar>();
+		private List<ILoad> ReadBarLoad(List<string> ids = null)
+		{
+			//Find all possible Load cases
+			Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
+			List<int> loadCaseIds = loadCaseMap.Keys.ToList();
+			Dictionary<int, Bar> memberMap = this.GetCachedOrReadAsDictionary<int, Bar>();
 
 
-            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_MEMBER_LOAD);
+			rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_MEMBER_LOAD);
 
-            IEnumerable<rfModel.member_load> foundLoadCases = numbers.SelectMany(n => n.children.ToList().Select(child => m_Model.get_member_load(child, n.no)));
+			IEnumerable<rfModel.member_load> foundLoadCases = numbers.SelectMany(n => n.children.ToList().Select(child => m_Model.get_member_load(child, n.no)));
 
-            List<ILoad> loadCases = new List<ILoad>();
-            foundLoadCases=foundLoadCases.OrderBy(n => n.load_case).ThenBy(t=>t.no);
-            foreach (rfModel.member_load memberLoad in foundLoadCases)
-            {
+			List<ILoad> loadCases = new List<ILoad>();
+			foundLoadCases = foundLoadCases.OrderBy(n => n.load_case).ThenBy(t => t.no);
+			foreach (rfModel.member_load memberLoad in foundLoadCases)
+			{
 
-                loadCases.Add(memberLoad.FromRFEM(memberLoad.members.ToList().Select(m => memberMap[m]).ToList(), loadCaseMap[memberLoad.load_case]));
+				loadCases.Add(memberLoad.FromRFEM(memberLoad.members.ToList().Select(m => memberMap[m]).ToList(), loadCaseMap[memberLoad.load_case]));
 
-            }
+			}
 
-            return loadCases;
-        }
+			return loadCases;
+		}
 
-        private List<ILoad> ReadPointLoad(List<string> ids = null)
-        {
-            //Find all possible Load cases
-            Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
-            Dictionary<int, Node> memberMap = this.GetCachedOrReadAsDictionary<int, Node>();
+		private List<ILoad> ReadPointLoad(List<string> ids = null)
+		{
+			//Find all possible Load cases
+			Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
+			Dictionary<int, Node> memberMap = this.GetCachedOrReadAsDictionary<int, Node>();
 
 
-            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODAL_LOAD);
+			rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODAL_LOAD);
 
-            //IEnumerable<rfModel.nodal_load> founeNodalLoad = numbers.ToList().Select(n => m_Model.get_nodal_load(n.children[0], n.no));
-            IEnumerable<rfModel.nodal_load> founeNodalLoad = numbers.SelectMany(n => n.children.Select(child => m_Model.get_nodal_load(child, n.no)));
+			//IEnumerable<rfModel.nodal_load> founeNodalLoad = numbers.ToList().Select(n => m_Model.get_nodal_load(n.children[0], n.no));
+			IEnumerable<rfModel.nodal_load> founeNodalLoad = numbers.SelectMany(n => n.children.Select(child => m_Model.get_nodal_load(child, n.no)));
 
-            List<ILoad> loads = new List<ILoad>();
-            foreach (rfModel.nodal_load nodeLoad in founeNodalLoad)
-            {
-                if (nodeLoad.load_type == rfModel.nodal_load_load_type.LOAD_TYPE_MASS)
-                {
+			List<ILoad> loads = new List<ILoad>();
+			foreach (rfModel.nodal_load nodeLoad in founeNodalLoad)
+			{
+				if (nodeLoad.load_type == rfModel.nodal_load_load_type.LOAD_TYPE_MASS)
+				{
 
-                    BH.Engine.Base.Compute.RecordWarning($"Nodal Loads of type {nodeLoad.load_type} can not be read from RFEM6. If possible convert them to either Force, Moment or Components!");
-                    continue;
-                }
+					BH.Engine.Base.Compute.RecordWarning($"Nodal Loads of type {nodeLoad.load_type} can not be read from RFEM6. If possible convert them to either Force, Moment or Components!");
+					continue;
+				}
 
-                loads.Add(nodeLoad.FromRFEM(nodeLoad.nodes.ToList().Select(m => memberMap[m]).ToList(), loadCaseMap[nodeLoad.load_case]));
+				loads.Add(nodeLoad.FromRFEM(nodeLoad.nodes.ToList().Select(m => memberMap[m]).ToList(), loadCaseMap[nodeLoad.load_case]));
 
-            }
+			}
 
-            return loads;
-        }
+			return loads;
+		}
 
 
 
 
-        private List<ILoad> ReadAreaLoad(List<string> ids = null)
-        {
-            List<ILoad> loads = new List<ILoad>();
+		private List<ILoad> ReadAreaLoad(List<string> ids = null)
+		{
+			List<ILoad> loads = new List<ILoad>();
 
-            //Find all possible Load cases
-            Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
-            Dictionary<int, Panel> panelMap = this.GetCachedOrReadAsDictionary<int, Panel>();
+			//Find all possible Load cases
+			Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
+			Dictionary<int, Panel> panelMap = this.GetCachedOrReadAsDictionary<int, Panel>();
 
-            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_SURFACE_LOAD);
+			rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_SURFACE_LOAD);
 
-            //IEnumerable<rfModel.surface_load> foundSurfaceLoad = numbers.ToList().Select(n => m_Model.get_surface_load(n.children[0], n.no));
-            IEnumerable<rfModel.surface_load> foundSurfaceLoad = numbers.SelectMany(n => n.children.Select(child => m_Model.get_surface_load(child, n.no)));
+			//IEnumerable<rfModel.surface_load> foundSurfaceLoad = numbers.ToList().Select(n => m_Model.get_surface_load(n.children[0], n.no));
+			IEnumerable<rfModel.surface_load> foundSurfaceLoad = numbers.SelectMany(n => n.children.Select(child => m_Model.get_surface_load(child, n.no)));
 
-            foundSurfaceLoad = foundSurfaceLoad.OrderBy(n => n.load_case).ThenBy(t => t.no);
-            foreach (rfModel.surface_load surfaceLoad in foundSurfaceLoad)
-            {
-                List<Panel> panels = surfaceLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
-                Loadcase loadcase = loadCaseMap[surfaceLoad.load_case];
+			foundSurfaceLoad = foundSurfaceLoad.OrderBy(n => n.load_case).ThenBy(t => t.no);
+			foreach (rfModel.surface_load surfaceLoad in foundSurfaceLoad)
+			{
+				List<Panel> panels = surfaceLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
+				Loadcase loadcase = loadCaseMap[surfaceLoad.load_case];
 
-                if (!(surfaceLoad.load_distribution is rfModel.surface_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
-                {
-                    Engine.Base.Compute.RecordNote("The current RFEM6 includes Surfaceloads with a non-uniformal load distributeion, these Loads will not be pulled.");
-                    continue;
-                }
+				if (!(surfaceLoad.load_distribution is rfModel.surface_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
+				{
+					Engine.Base.Compute.RecordNote("The current RFEM6 includes Surfaceloads with a non-uniformal load distributeion, these Loads will not be pulled.");
+					continue;
+				}
 
-                loads.Add(surfaceLoad.FromRFEM(loadCaseMap[surfaceLoad.load_case], panels));
+				loads.Add(surfaceLoad.FromRFEM(loadCaseMap[surfaceLoad.load_case], panels));
 
-            }
+			}
 
-            return loads;
-        }
+			return loads;
+		}
 
-        private List<ILoad> ReadFreeLineLoad(List<string> ids = null)
-        {
-            List<ILoad> loads = new List<ILoad>();
+		private List<ILoad> ReadFreeLineLoad(List<string> ids = null)
+		{
+			List<ILoad> loads = new List<ILoad>();
 
-            Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
-            Dictionary<int, Panel> panelMap = this.GetCachedOrReadAsDictionary<int, Panel>();
+			Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
+			Dictionary<int, Panel> panelMap = this.GetCachedOrReadAsDictionary<int, Panel>();
 
 
-            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD);
-            //rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.line);
+			rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD);
+		
+			List<rfModel.free_line_load> foundFreeLineLoads = new List<rfModel.free_line_load>();
+			foreach (var num in numbers ) {
 
+				var loadNumbers=num.children.ToList();
+			
+				foreach (var loadNumber in loadNumbers)
+				{
+					var freeLineLoad = m_Model.get_free_line_load(loadNumber, num.no);
+					foundFreeLineLoads.Add(freeLineLoad);
+				}
 
-            //IEnumerable<rfModel.free_line_load> foundFreeLineLoads = numbers.ToList().Select(n => m_Model.get_free_line_load(n.children[0], n.no));
-            IEnumerable<rfModel.free_line_load> foundFreeLineLoads = numbers.SelectMany(n => n.children.Select(child => m_Model.get_free_line_load(child, n.no)));
+			}
 
+			foreach (rfModel.free_line_load freeLineLoad in foundFreeLineLoads)
+			{
+				List<Panel> panelList;
+				if (freeLineLoad.surfaces is null)
+				{
+					panelList = new List<Panel>();
+				}
+				else
+				{
 
-            foreach (rfModel.free_line_load freeLineLoad in foundFreeLineLoads)
-            {
-                List<Panel> panelList;
-                if (freeLineLoad.surfaces.ToList().First() == 0)
-                {
-                    panelList = new List<Panel>();
-                }
-                else
-                {
+					panelList = freeLineLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
 
-                    panelList = freeLineLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
+				}
+				loads.Add(freeLineLoad.FromRFEM(loadCaseMap[freeLineLoad.load_case], panelList));
+
+			}
+
+			return loads;
+		}
+
+
+		private List<ILoad> ReadLineLoad(List<string> ids = null)
+		{
+			List<ILoad> loads = new List<ILoad>();
+
+			Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
+			Dictionary<int, Edge> edgeDictionary = this.GetCachedOrReadAsDictionary<int, Edge>();
+
+
+			rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD);
+			//rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.line);
 
-                }
-                loads.Add(freeLineLoad.FromRFEM(loadCaseMap[freeLineLoad.load_case], panelList));
 
-            }
+			//IEnumerable<rfModel.line_load> foundFreeLineLoads = numbers.ToList().Select(n => m_Model.get_line_load(n.children[0], n.no));
+			//IEnumerable<rfModel.line_load> foundFreeLineLoads = numbers.SelectMany(n => n.children.Select(child => m_Model.get_line_load(child, n.no)));
 
-            return loads;
-        }
+			List<rfModel.line_load> foundFreeLineLoads = new List<rfModel.line_load>();
+			foreach (var num in numbers)
+			{
 
+				var loadNumbers = num.children.ToList();
 
-        private List<ILoad> ReadLineLoad(List<string> ids = null)
-        {
-            List<ILoad> loads = new List<ILoad>();
+				foreach (var loadNumber in loadNumbers)
+				{
+					var lineLoad = m_Model.get_line_load(loadNumber, num.no);
+					foundFreeLineLoads.Add(lineLoad);
+				}
 
-            Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
-            Dictionary<int, Edge> edgeDictionary = this.GetCachedOrReadAsDictionary<int, Edge>();
+			}
 
 
-            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD);
-            //rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.line);
+			foreach (rfModel.line_load lineLoad in foundFreeLineLoads)
+			{
 
+				List<ICurve> curveList = lineLoad.lines.ToList().Select(l => edgeDictionary[l].Curve).Where(cu => (cu is Line) || (cu is Polyline && cu.ControlPoints().Count == 2)).ToList();
+				List<Line> lines = curveList.Select(k => new Line() { Start = k.ControlPoints().First(), End = k.ControlPoints().First() }).ToList();
+				lines.ForEach(l => loads.Add(lineLoad.FromRFEM(loadCaseMap[lineLoad.load_case], l)));
 
-            //IEnumerable<rfModel.line_load> foundFreeLineLoads = numbers.ToList().Select(n => m_Model.get_line_load(n.children[0], n.no));
-            IEnumerable<rfModel.line_load> foundFreeLineLoads = numbers.SelectMany(n => n.children.Select(child => m_Model.get_line_load(child, n.no)));
+			}
 
+			return loads;
+		}
 
-            foreach (rfModel.line_load lineLoad in foundFreeLineLoads)
-            {
+		private void UpdateLoadIdDictionary(ILoad load)
+		{
 
-                List<ICurve> curveList = lineLoad.lines.ToList().Select(l => edgeDictionary[l].Curve).Where(cu => (cu is Line) || (cu is Polyline && cu.ControlPoints().Count == 2)).ToList();
-                List<Line> lines = curveList.Select(k => new Line() { Start = k.ControlPoints().First(), End = k.ControlPoints().First() }).ToList();
-                lines.ForEach(l => loads.Add(lineLoad.FromRFEM(loadCaseMap[lineLoad.load_case], l)));
+			//Determin LoadType. Lineloads are handled differently as there is the need to discriminate between free and non-free line loads
+			var rfLoadType = load.GetType().ToRFEM6().Value;
+			bool lineLoadhasFragments = false;
+			bool isFreeLineLoad = false;
+			if (load is GeometricalLineLoad geomLineLoad)
+			{
 
-            }
+				lineLoadhasFragments = load.Fragments.ToList().Any(f => f.GetType().Name == "RFEM6GeometricalLineLoadTypes");
+				isFreeLineLoad = lineLoadhasFragments ? BH.Engine.Base.Query.GetAllFragments(load)[0].PropertyValue("geometrialLineLoadType").ToString().Equals("FreeLineLoad") : true;
 
-            return loads;
-        }
+				rfLoadType = (lineLoadhasFragments || isFreeLineLoad) ? rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD : rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD;
+			}
+			else
+			{
 
-        private void UpdateLoadIdDictionary(ILoad load)
-        {
+				rfLoadType = load.GetType().ToRFEM6().Value;
+			}
 
-            //Determin LoadType. Lineloads are handled differently as there is the need to discriminate between free and non-free line loads
-            var rfLoadType = load.GetType().ToRFEM6().Value;
-            bool lineLoadhasFragments = false;
-            bool isFreeLineLoad = false;
-            if (load is GeometricalLineLoad geomLineLoad)
-            {
+			//Check if the loadcase is already in the dictionary
+			if (m_LoadcaseLoadIdDict.TryGetValue(load.Loadcase, out Dictionary<String, int> loadIdDict))
+			{
+				String type = load.GetType().Name;
 
-                lineLoadhasFragments = load.Fragments.ToList().Any(f => f.GetType().Name == "RFEM6GeometricalLineLoadTypes");
-                isFreeLineLoad = lineLoadhasFragments ? BH.Engine.Base.Query.GetAllFragments(load)[0].PropertyValue("geometrialLineLoadType").ToString().Equals("FreeLineLoad") : true;
+				if (load is GeometricalLineLoad geoLineLoad)
+				{
+					// Assuming 'Designation' is the property that indicates 'Free' or 'NonFree'
+					//type += "_" + geoLineLoad.Name; // e.g., "GeometricalLineLoad_Free"
+					type += "_" + (!isFreeLineLoad ? "NonFreeLineLoad" : "FreeLineLoad");
 
-                rfLoadType = (lineLoadhasFragments || isFreeLineLoad) ? rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD : rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD;
-            }
-            else
-            {
+				}
 
-                rfLoadType = load.GetType().ToRFEM6().Value;
-            }
+				if (loadIdDict.TryGetValue(type, out int id))
+				{
+					loadIdDict[type] = id + 1;
+				}
+				else
+				{
+					int k = m_Model.get_first_free_number(rfLoadType, load.Loadcase.Number);
+					loadIdDict.Add(type, k);
+				}
+			}
+			else
+			{
+				var d = new Dictionary<string, int>();
+				String type = load.GetType().Name;
+				if (load is GeometricalLineLoad geoLineLoad)
+				{
+					//type += "_" + geoLineLoad.Name;
+					type += "_" + (!isFreeLineLoad ? "NonFreeLineLoad" : "FreeLineLoad");
+					//var rfLoadType = geoLineLoad.Name == "Free" ? rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD : rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD;
+					d.Add(type, m_Model.get_first_free_number(rfLoadType, load.Loadcase.Number));
+					m_LoadcaseLoadIdDict.Add(load.Loadcase, d);
 
-            //Check if the loadcase is already in the dictionary
-            if (m_LoadcaseLoadIdDict.TryGetValue(load.Loadcase, out Dictionary<String, int> loadIdDict))
-            {
-                String type = load.GetType().Name;
+				}
+				else
+				{
+					d.Add(type, m_Model.get_first_free_number(load.GetType().ToRFEM6().Value, load.Loadcase.Number));
+					m_LoadcaseLoadIdDict.Add(load.Loadcase, d);
+				}
 
-                if (load is GeometricalLineLoad geoLineLoad)
-                {
-                    // Assuming 'Designation' is the property that indicates 'Free' or 'NonFree'
-                    //type += "_" + geoLineLoad.Name; // e.g., "GeometricalLineLoad_Free"
-                    type += "_" + (!isFreeLineLoad ? "NonFreeLineLoad" : "FreeLineLoad");
+			}
 
-                }
+		}
 
-                if (loadIdDict.TryGetValue(type, out int id))
-                {
-                    loadIdDict[type] = id + 1;
-                }
-                else
-                {
-                    int k = m_Model.get_first_free_number(rfLoadType, load.Loadcase.Number);
-                    loadIdDict.Add(type, k);
-                }
-            }
-            else
-            {
-                var d = new Dictionary<string, int>();
-                String type = load.GetType().Name;
-                if (load is GeometricalLineLoad geoLineLoad)
-                {
-                    //type += "_" + geoLineLoad.Name;
-                    type += "_" + (!isFreeLineLoad ? "NonFreeLineLoad" : "FreeLineLoad");
-                    //var rfLoadType = geoLineLoad.Name == "Free" ? rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD : rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD;
-                    d.Add(type, m_Model.get_first_free_number(rfLoadType, load.Loadcase.Number));
-                    m_LoadcaseLoadIdDict.Add(load.Loadcase, d);
 
-                }
-                else
-                {
-                    d.Add(type, m_Model.get_first_free_number(load.GetType().ToRFEM6().Value, load.Loadcase.Number));
-                    m_LoadcaseLoadIdDict.Add(load.Loadcase, d);
-                }
 
-            }
-
-        }
-
-
-
-    }
+	}
 
 }
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -198,9 +198,6 @@ namespace BH.Adapter.RFEM6
         private void UpdateLoadIdDictionary(ILoad load)
         {
 
-
-
-
             //Determin LoadType. Lineloads are handled differently as there is the need to discriminate between free and non-free line loads
             var rfLoadType = load.GetType().ToRFEM6().Value;
             bool lineLoadhasFragments = false;
@@ -238,7 +235,7 @@ namespace BH.Adapter.RFEM6
                 }
                 else
                 {
-                    int k = m_Model.get_first_free_number(rfLoadType, load.Loadcase.GetRFEM6ID());
+                    int k = m_Model.get_first_free_number(rfLoadType, load.Loadcase.Number);
                     loadIdDict.Add(type, k);
                 }
             }
@@ -251,13 +248,13 @@ namespace BH.Adapter.RFEM6
                     //type += "_" + geoLineLoad.Name;
                     type += "_" + (!isFreeLineLoad ? "NonFreeLineLoad" : "FreeLineLoad");
                     //var rfLoadType = geoLineLoad.Name == "Free" ? rfModel.object_types.E_OBJECT_TYPE_FREE_LINE_LOAD : rfModel.object_types.E_OBJECT_TYPE_LINE_LOAD;
-                    d.Add(type, m_Model.get_first_free_number(rfLoadType, load.Loadcase.GetRFEM6ID()));
+                    d.Add(type, m_Model.get_first_free_number(rfLoadType, load.Loadcase.Number));
                     m_LoadcaseLoadIdDict.Add(load.Loadcase, d);
 
                 }
                 else
                 {
-                    d.Add(type, m_Model.get_first_free_number(load.GetType().ToRFEM6().Value, load.Loadcase.GetRFEM6ID()));
+                    d.Add(type, m_Model.get_first_free_number(load.GetType().ToRFEM6().Value, load.Loadcase.Number));
                     m_LoadcaseLoadIdDict.Add(load.Loadcase, d);
                 }
 

--- a/RFEM6_Adapter/Comparers/PanelComparer.cs
+++ b/RFEM6_Adapter/Comparers/PanelComparer.cs
@@ -19,47 +19,56 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using BH.oM.Adapter;
 using BH.oM.Structure.Elements;
+using BH.Engine.Structure;
+using System.Linq;
+using BH.oM.Analytical.Elements;
 using BH.oM.Geometry;
-using BH.oM.Structure.MaterialFragments;
-using BH.oM.Structure.SectionProperties;
-using BH.oM.Adapters.RFEM6;
-
-using rfModel = Dlubal.WS.Rfem6.Model;
-using BH.Engine.Base;
+using BH.Engine.Geometry;
+using BH.oM.Adapters.RFEM6.IntermediateDatastructure.Geometry;
+using BH.Engine.Spatial;
 
 namespace BH.Adapter.RFEM6
 {
-    public partial class RFEM6Adapter
+    public class PanelComparer : IEqualityComparer<Panel>
     {
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
 
-		private bool CreateCollection(IEnumerable<Panel> bhPanels)
-		{
-			foreach (Panel bhPanel in bhPanels)
-			{
-				rfModel.surface surface = bhPanel.ToRFEM6();
+        public PanelComparer()
+        {
 
-				if (m_PanelIDdict.ContainsKey(bhPanel))
-				{
-					m_PanelIDdict[bhPanel] = bhPanel.GetRFEM6ID();
-				}
-				else
-				{
-					m_PanelIDdict.Add(bhPanel, bhPanel.GetRFEM6ID());
-				}
+        }
 
-				m_Model.set_surface(surface);
-			}
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
 
-			return true;
-		}
+        public bool Equals(Panel panel0, Panel panel1)
+        {
+         
+            if(panel0.Centroid().Distance(panel1.Centroid())<0.001) return true;
 
+            return false;
+        }
+
+        /***************************************************/
+
+        public int GetHashCode(Panel panel)
+        {
+            //Check whether the object is null
+            return 0; 
+        }
+
+        /***************************************************/
     }
 }
+
+
+
+
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -242,7 +242,7 @@ namespace BH.Adapter.RFEM6
                 no = loadCaseSpecificLoadId,
                 comment = bhAreaLoad.Name,
                 surfaces = bhAreaLoad.Objects.Elements.ToList().Select(x => (x as Panel).GetRFEM6ID()).ToArray(),
-                load_case = bhAreaLoad.Loadcase.GetRFEM6ID(),
+                load_case = bhAreaLoad.Loadcase.Number,
                 load_caseSpecified = true,
                 load_distribution = surface_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
                 load_distributionSpecified = true,
@@ -342,7 +342,7 @@ namespace BH.Adapter.RFEM6
                 surfaces_string = string.Join(" ", surfaceIds.Select(n => n.ToString())),
 
                 no = loadCaseSpecificID,
-                load_case = bhLineLoad.Loadcase.GetRFEM6ID(),
+                load_case = bhLineLoad.Loadcase.Number,
                 load_caseSpecified = true,
                 load_distribution = free_line_load_load_distribution.LOAD_DISTRIBUTION_LINEAR,
                 load_distributionSpecified = true,
@@ -506,7 +506,7 @@ namespace BH.Adapter.RFEM6
             {
                 no = id,
                 lines = new int[] { foundEdgeId },
-                load_case = bhLineLoad.Loadcase.GetRFEM6ID(),
+                load_case = bhLineLoad.Loadcase.Number,
                 load_caseSpecified = true,
                 load_distribution = line_load_load_distribution.LOAD_DISTRIBUTION_TRAPEZOIDAL,
                 load_distributionSpecified = true,

--- a/RFEM6_Adapter/RFEM6AdapterSettings.cs
+++ b/RFEM6_Adapter/RFEM6AdapterSettings.cs
@@ -110,8 +110,9 @@ namespace BH.Adapter.RFEM6
                 {typeof(Edge), new EdgeComparer()},
                 {typeof(RFEMLineSupport), new RFEMLineSupportComparer() },
                 {typeof(RFEMLine), new RFEMLineComparer(3) },
-                {typeof(Panel), new RFEMPanelComparer() },
-                {typeof(Loadcase), new LoadCaseComparer() },
+                //{typeof(Panel), new RFEMPanelComparer() },
+				{typeof(Panel), new PanelComparer() },
+				{typeof(Loadcase), new LoadCaseComparer() },
             };
              
            


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
When pushing loads or load cases, the adapter attempts to call the next ID method. However, due to some RFEM6-specific issues, this is not an option. Despite that, the current version still performs this action, resulting in an error.

Closes #89 

<!-- Add short description of what has been fixed -->
With this PR the issue should be resolved and Loads should be able to be pushed without bigger problems. 

### Test files
<!-- Link to test files to validate the proposed changes -->
[Link](https://burohappold.sharepoint.com/:u:/s/BHoM/ERGMfo0gDvFKjtb0kEFkILwBy_wKC2g6kyhsuJmfyCADxA?e=kondma)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Changed `LoadCase.GetRFEMID()` to `LoadCase.Number` to prevent error. 

### Additional comments
<!-- As required -->

