### PR TITLE
Problem When Pushing Loads with and LoadCase which has alreacy been defined in RFEM6

### DIFF
--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
@@ -46,9 +46,11 @@ namespace BH.Adapter.RFEM6
 
         public IEnumerable<IResult> ReadResults(NodeResultRequest request, ActionConfig actionConfig)
         {
+            
+           
 
-            List<int> nodeIds = request.ObjectIds.Select(s => Int32.Parse((String)s)).ToList();
-            List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse((String)s)).ToList();
+            List<int> nodeIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
+            List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
 
             switch (request.ResultType)
             {

--- a/RFEM6_Adapter/Comparers/LoadcaseComparar.cs
+++ b/RFEM6_Adapter/Comparers/LoadcaseComparar.cs
@@ -49,19 +49,9 @@ namespace BH.Adapter.RFEM6
         public bool Equals(Loadcase loadcase0, Loadcase loadcase1)
         {
 
-            //Checks if one Name is equals to Null and one is not
-            if ((loadcase0.Name == null && loadcase1.Name != null)|| (loadcase0.Name != null && loadcase1.Name == null))
-            {
-                return false;
-            }
+            if(!string.Equals(loadcase0.Name,loadcase1.Name)) return false;
 
-            //Checks if both Names are equal and not null or both are null
-            if (!(loadcase0.Name?.Equals(loadcase1.Name) ?? loadcase1.Name==null)) {
-                return false;
-            
-            }
             if(!loadcase0.Number.Equals(loadcase1.Number)) return false;
-
 
             if (!loadcase0.Nature.Equals(loadcase1.Nature)) { return false; }
 

--- a/RFEM6_Adapter/Comparers/LoadcaseComparar.cs
+++ b/RFEM6_Adapter/Comparers/LoadcaseComparar.cs
@@ -60,13 +60,7 @@ namespace BH.Adapter.RFEM6
                 return false;
             
             }
-
-
-            //if (!(loadcase0.Name == null && loadcase1.Name == null))
-            //{
-            //    //if (!loadcase0.Name?.Equals(loadcase1.Name) ?? loadcase1.Name == null) { return false; }
-            //    if (!loadcase0.Name.Equals(loadcase1.Name)) { return false; }
-            //}
+            if(!loadcase0.Number.Equals(loadcase1.Number)) return false;
 
 
             if (!loadcase0.Nature.Equals(loadcase1.Nature)) { return false; }

--- a/RFEM6_Adapter/Comparers/RFEMSectionComparer.cs
+++ b/RFEM6_Adapter/Comparers/RFEMSectionComparer.cs
@@ -50,12 +50,14 @@ namespace BH.Adapter.RFEM6
             //Check whether any of the compared objects is null.
             if (Object.ReferenceEquals(section1, null) || Object.ReferenceEquals(section2, null))
                 return false;
-            if (!(section1 is GenericSection || section2 is GenericSection)) {
+            if (!(section1 is GenericSection || section2 is GenericSection))
+            {
                 Convert.AlterSectionName(section1);
                 Convert.AlterSectionName(section2);
             }
-            if(section1.Name.Equals(section2.Name)&&section1.Material.Name.Equals(section2.Material.Name)) return true;
 
+            bool sectionTypeDoesMatch = String.Equals(section1.Name, section2.Name);
+            bool materialDoesMatch = String.Equals(section1.Material.Name, section2.Material.Name);
 
             return false;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Push of Loads with and already existin LoadCase with an equivalent Nature results in an error messages and in the Load not beeing pushed into RFEM6.

Another minor issue that has been fixed was that the pull of nodal reactions was not possible from Excel due to some impossible casting to string. This has been taken care of. 

Closes #92 
Closes #94 

<!-- Add short description of what has been fixed -->
Comparars for both LoadCases well as Section have been modifies. For the Testing please just Push all gemetrical elements and after that push all loads. The result should be Geometry in RFEM6 and Loads plus appopriatly names and numberated Loadcasese. 

Please Try to read nodal loads from Both the GH file and the Excel File. 

### Test files
<!-- Link to test files to validate the proposed changes -->
[Link GH Script ](https://burohappold.sharepoint.com/:u:/s/BHoM/EeRptLyQuVJGgG16ySfTZCkBgPrtMmzHBOmWtRaAGUEdzA?e=BG8aMy)
[Link Excel File](https://burohappold.sharepoint.com/:x:/s/BHoM/EWuacWUWhEBMuFw6mvtjaAcBAYh3nzN1ksnU_7rO8HFYdA?e=DVgFGP)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Alteration of Comparer for Loadcases
-  Alteration of Comparer for Sections