### PR TITLE
After RFEM6 update RFEM6_Toolkit stopped working. 

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Comparer/Section.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Comparer/Section.cs
@@ -43,94 +43,145 @@ using System.Threading.Tasks;
 
 namespace RFEM_Toolkit_Test.Comparer_Tests
 {
-    internal class Section
+	internal class Section
 
-    {
+	{
 
-        RFEM6Adapter adapter;
-        ISectionProperty steelSection1;
-        ISectionProperty steelSection2;
-        ISectionProperty concreteSection0;
-        ISectionProperty concreteSection1;
-        ISectionProperty genericSectionGLTimber;
-        ISectionProperty genericSectionSawnTimber;
-        IProfile rectProfileGLTimber;
-        IProfile circleProfileSawnTimber;
-        IProfile concreteProfile0;
-        IProfile concreteProfile1;
+		RFEM6Adapter adapter;
+		ISectionProperty steelSection1;
+		ISectionProperty steelSection2;
+		ISectionProperty steelSection3;
+		ISectionProperty steelSection4;
+		ISectionProperty concreteSection0;
+		ISectionProperty concreteSection1;
+		ISectionProperty concreteSection2;
+		ISectionProperty concreteSection3;
+		ISectionProperty genericSectionGLTimber;
+		ISectionProperty genericSectionSawnTimber;
+		IProfile rectProfileGLTimber;
+		IProfile circleProfileSawnTimber;
+		IProfile concreteProfile0;
+		IProfile concreteProfile1;
 
-        IMaterialFragment glulam;
-        IMaterialFragment timberC;
-        Concrete concrete0;
-        Concrete concrete1;
+		IMaterialFragment glulam;
+		IMaterialFragment timberC;
+		Concrete concrete0;
+		Concrete concrete1;
+		Concrete concrete01;
+		Concrete concrete11;
 
-        RFEMSectionComparer comparer;
+		RFEMSectionComparer comparer;
 
-        //[SetUp]
-        //public void Setup()
-        //{
-            
-        //}
+		//[SetUp]
+		//public void Setup()
+		//{
 
-        [OneTimeSetUp]
-        public void InitializeRFEM6Adapter()
-        {
+		//}
 
-            adapter = new RFEM6Adapter(true);
-            comparer = new RFEMSectionComparer();
+		[OneTimeSetUp]
+		public void InitializeRFEM6Adapter()
+		{
 
-        }
+			adapter = new RFEM6Adapter(true);
+			comparer = new RFEMSectionComparer();
 
-        [Test]
-        public void StandardConcreteSections()
-        {
-            /***************************************************/
-            /**** Test Preparation                          ****/
-            /***************************************************/
-            concrete0 = BH.Engine.Library.Query.Match("Concrete", "C25/30", true, true).DeepClone() as Concrete;
-            concrete1 = BH.Engine.Library.Query.Match("Concrete", "C45/55", true, true).DeepClone() as Concrete;
+		}
 
+		[Test]
+		public void StandardConcreteSections()
+		{
+			/***************************************************/
+			/****          Arrange                          ****/
+			/***************************************************/
+			concrete0 = BH.Engine.Library.Query.Match("Concrete", "C25/30", true, true).DeepClone() as Concrete;
+			concrete01 = BH.Engine.Library.Query.Match("Concrete", "C25/30", true, true).DeepClone() as Concrete;
 
-            concreteProfile0 = BH.Engine.Spatial.Create.CircleProfile(0.2);
-            concreteSection0 = BH.Engine.Structure.Create.GenericSectionFromProfile(concreteProfile0, concrete0, "ConcreteSection1");
-
-            concreteProfile1 = BH.Engine.Spatial.Create.CircleProfile(0.5);
-            concreteSection1 = BH.Engine.Structure.Create.GenericSectionFromProfile(concreteProfile1, concrete1, "ConcreteSection2");
-
-            adapter.Push(new List<ISectionProperty>() { concreteSection0});
-
-            FilterRequest sectionFilter = new FilterRequest() { Type = typeof(ISectionProperty) };
-            var sectionsPulled = adapter.Pull(sectionFilter).Select(s => (ConcreteSection)s).ToList().First();
-
-            /***************************************************/
-            /**** Assertions                                ****/
-            /***************************************************/
-
-            //Assert.IsTrue(comparer.Equals(sectionsPulled,ConcreteSection0));
+			concrete1 = BH.Engine.Library.Query.Match("Concrete", "C45/55", true, true).DeepClone() as Concrete;
+			concrete11 = BH.Engine.Library.Query.Match("Concrete", "C45/55", true, true).DeepClone() as Concrete;
 
 
+			concreteProfile0 = BH.Engine.Spatial.Create.CircleProfile(0.2);
+			concreteSection0 = BH.Engine.Structure.Create.GenericSectionFromProfile(concreteProfile0, concrete0, "ConcreteSection1");
 
-        }
+			concreteProfile1 = BH.Engine.Spatial.Create.CircleProfile(0.5);
+			concreteSection1 = BH.Engine.Structure.Create.GenericSectionFromProfile(concreteProfile1, concrete1, "ConcreteSection2");
 
-        [Test]
-        public void StandardSteelSections()
-        {
-           //TODO: Implement
-        }
+			adapter.Push(new List<ISectionProperty>() { concreteSection0 });
 
-        [Test]
-        public void GenericTimberSections()
-        {
-            //TODO: Implement
-        }
+			FilterRequest sectionFilter = new FilterRequest() { Type = typeof(ISectionProperty) };
+			var sectionsPulled = adapter.Pull(sectionFilter).Select(s => (ConcreteSection)s).ToList().First();
 
-        [Test]
-        public void GenericConcreteSections()
-        {
-            //TODO: Implement
-        }
+			/***************************************************/
+			/**** Asserti                                   ****/
+			/***************************************************/
+
+			//Assert.IsTrue(comparer.Equals(sectionsPulled,ConcreteSection0));
 
 
-    }
+
+		}
+
+		[Test]
+		public void StandardSteelSections()
+		{
+
+
+			/***************************************************/
+			/****          Arrange                          ****/
+			/***************************************************/
+
+			steelSection1 = BH.Engine.Library.Query.Match("EU_SteelSections", "IPE 300", true, true).DeepClone() as ISectionProperty;
+			steelSection2 = BH.Engine.Library.Query.Match("EU_SteelSections", "IPE 300", true, true).DeepClone() as ISectionProperty;
+			
+			adapter.Push(new List<ISectionProperty>(){steelSection1});
+			FilterRequest sectionFilter = new FilterRequest() { Type = typeof(ISectionProperty) };
+			var tst = adapter.Pull(sectionFilter);
+			steelSection3 = adapter.Pull(sectionFilter).Select(s => (ISectionProperty)s).ToList().First();
+
+			steelSection4 = BH.Engine.Library.Query.Match("EU_SteelSections", "IPE 550", true, true).DeepClone() as ISectionProperty;
+
+			/***************************************************/
+			/****          Act                              ****/
+			/***************************************************/
+
+			bool OrgSec1_Vs_OrgSec1 = comparer.Equals(steelSection1, steelSection1);
+			bool OrgSec1_Vs_OrgSec2 = comparer.Equals(steelSection1, steelSection2);
+			bool OrgSec1_Vs_PullSec3 = comparer.Equals(steelSection1, steelSection3);
+			bool OrgSec1_Vs_OrgSec4 = comparer.Equals(steelSection1, steelSection4);
+
+
+			/***************************************************/
+			/****          Assert                           ****/
+			/***************************************************/
+			
+			//Checking Steel Section Agains it self
+			Assert.IsTrue(OrgSec1_Vs_OrgSec1);
+
+			// Checking Steel Section agains its Copy 
+			Assert.IsTrue(OrgSec1_Vs_OrgSec2);
+
+			// Checking Steel Section agains its Push/Pulled version
+			Assert.IsTrue(OrgSec1_Vs_PullSec3);
+
+			// Checking Steel Sectin agains a differnt Steel Section
+			Assert.IsTrue(!OrgSec1_Vs_OrgSec4);
+
+
+		}
+
+		[Test]
+		public void GenericTimberSections()
+		{
+			//TODO: Implement
+		}
+
+		[Test]
+		public void GenericConcreteSections()
+		{
+			//TODO: Implement
+		}
+
+
+	}
 }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/NodalResult.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/NodalResult.cs
@@ -27,63 +27,88 @@ using BH.Engine.Structure;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
+using BH.oM.Analytical.Elements;
+using BH.oM.Base;
+using BH.oM.Structure.Requests;
 
 namespace RFEM_Toolkit_Test.Elements
 {
 
 
-    public class NodalResultTestClass
+	public class NodalResultTestClass
 
-    {
+	{
 
-        RFEM6Adapter adapter;
+		RFEM6Adapter adapter;
 
-        Line line0;
-        Line line1;
-        Line line2;
-        Line line3;
-
-
-
-        IMaterialFragment glulam;
-        IMaterialFragment timberC;
-        //IMaterialFragment timberT;
-        //IMaterialFragment timberD;
-
-        Concrete concrete;
-        //IMaterialFragment steel;
-
-        ISectionProperty steelSection;
-        ISectionProperty concreteSection;
-        ISectionProperty genericSectionGLTimber;
-        ISectionProperty genericSectionSawnTimber;
-
-        Bar barSteelSection;
-        Bar barConcreteSection;
-        Bar barGLTimber;
-        Bar barSawTimber;
-
-        BarEndNodesDistanceComparer comparer = new BarEndNodesDistanceComparer(3);
-
-        [TearDown]
-        public void TearDown()
-        {
-            adapter.Wipeout();
-        }
-
-        [OneTimeSetUp]
-        public void InitializeRFEM6Adapter()
-        {
-            adapter = new RFEM6Adapter(true);
-
-            
-            
-
-        }
+		Line line0;
+		Line line1;
+		Line line2;
+		Line line3;
 
 
-      
+
+		IMaterialFragment glulam;
+		IMaterialFragment timberC;
+		//IMaterialFragment timberT;
+		//IMaterialFragment timberD;
+
+		Concrete concrete;
+		//IMaterialFragment steel;
+
+		ISectionProperty steelSection;
+		ISectionProperty concreteSection;
+		ISectionProperty genericSectionGLTimber;
+		ISectionProperty genericSectionSawnTimber;
+
+		Bar barSteelSection;
+		Bar barConcreteSection;
+		Bar barGLTimber;
+		Bar barSawTimber;
+
+		BarEndNodesDistanceComparer comparer = new BarEndNodesDistanceComparer(3);
+
+		[TearDown]
+		public void TearDown()
+		{
+			adapter.Wipeout();
+		}
+
+		[OneTimeSetUp]
+		public void InitializeRFEM6Adapter()
+		{
+			adapter = new RFEM6Adapter(true);
 
 
-    }
+
+
+		}
+
+		[Test]
+		public void ReadResult()
+		{
+
+			NodeResultRequest request = new NodeResultRequest();
+			request.Cases = new List<Object> { 1 };
+			request.ObjectIds = new List<object> { 1, 2, 3, 4, 5 ,6};
+			request.ResultType = NodeResultType.NodeReaction;
+
+			//Push it once
+			var obj = adapter.Pull(request);
+
+			obj.First();
+
+			////Pull it
+			//FilterRequest edgeFilter = new FilterRequest() { Type = typeof(Edge) };
+			//var edgePulled = adapter.Pull(edgeFilter).ToList();
+			//Edge ep = (Edge)edgePulled[0];
+
+			////Check
+			//Assert.IsNotNull(ep);
+			//Assert.True(comparer.Equals(edge1, ep));
+		}
+
+
+
+	}
 }

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
@@ -41,94 +41,113 @@ using System.Configuration;
 
 namespace BH.Adapter.RFEM6
 {
-    public partial class RFEM6Adapter
-    {
+	public partial class RFEM6Adapter
+	{
 
-        public IEnumerable<IResult> ReadResults(NodeResultRequest request, ActionConfig actionConfig)
-        {
-            
-           
-
-            List<int> nodeIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
-            List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
-
-            switch (request.ResultType)
-            {
-
-                case NodeResultType.NodeReaction:
-
-                    //m_Model.calculate_all(true);
-                    var result = ExtractNodeReaction(nodeIds, loadCaseIds);
-                    return result;
-
-                default:
-
-                    BH.Engine.Base.Compute.RecordWarning("WOOOOPS....Seems like Extraction has only been implemented for Node Reactions!");
-
-                    break;
-
-            }
-
-            return null;
-        }
-
-        private IEnumerable<IResult> ExtractNodeReaction(List<int> nodeIds, List<int> loadCaseIds)
-        {
-
-            List<IResult> resultList = new List<IResult>();
-
-            //If no node ids are provided, then we will extract the results for all nodes
-            if (nodeIds.Count == 0)
-            {
-                HashSet<int> nodalSupportNodeIDs = new HashSet<int>();
-                rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODAL_SUPPORT);
-                IEnumerable<rfModel.nodal_support> foundSupports = numbers.ToList().Select(n => m_Model.get_nodal_support(n.no));
-                foundSupports.ToList().ForEach(s => s.nodes.ToList().ForEach(n => nodalSupportNodeIDs.Add(n)));
-                nodeIds = nodalSupportNodeIDs.ToList();
-                BH.Engine.Base.Compute.RecordWarning("No Node Ids were provided for the extraction of Node Reactions, all supports were chosen istead.");
-            }
+		public IEnumerable<IResult> ReadResults(NodeResultRequest request, ActionConfig actionConfig)
+		{
 
 
 
-            m_Model.calculate_all(true);
-           
-            foreach (int lc in loadCaseIds)
-            {
+			List<int> nodeIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
+			List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
 
-                foreach (int n in nodeIds)
-                {
+			switch (request.ResultType)
+			{
 
-                    //nodes_support_forces_row[] nodes_support_forces_rows = m_Model.get_results_for_nodes_support_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, lc, n);
+				case NodeResultType.NodeReaction:
 
-                    //var supportResultReaction = nodes_support_forces_rows.First().row;
-                    //double fxValue = Double.Parse(supportResultReaction.support_force_p_x.value);
-                    //double fyValue = Double.Parse(supportResultReaction.support_force_p_y.value);
-                    //double fzValue = Double.Parse(supportResultReaction.support_force_p_z.value);
-                    //double mxValue = Double.Parse(supportResultReaction.support_moment_m_x.value);
-                    //double myValue = supportResultReaction.support_moment_m_y;
-                    //double mzValue = supportResultReaction.support_moment_m_z;
+					//m_Model.calculate_all(true);
+					var result = ExtractNodeReaction(nodeIds, loadCaseIds);
+					return result;
 
-                    double fxValue = 0;
-					double fyValue = 0;
-					double fzValue = 0;
-					double mxValue = 0;
-					double myValue = 0;
-					double mzValue = 0;
+				default:
 
-					NodeReaction nodeReaction = new NodeReaction(n, lc, 0, 0, oM.Geometry.Basis.XY, fxValue, fyValue, fzValue, mxValue, myValue, mzValue);
+					BH.Engine.Base.Compute.RecordWarning("WOOOOPS....Seems like Extraction has only been implemented for Node Reactions!");
 
-                    resultList.Add(nodeReaction);
+					break;
+
+			}
+
+			return null;
+		}
+
+		private IEnumerable<IResult> ExtractNodeReaction(List<int> nodeIds, List<int> loadCaseIds)
+		{
+
+			List<IResult> resultList = new List<IResult>();
+			object_location[] filter = null;
+
+			//If no node ids are provided, then we will extract the results for all nodes
+
+			//get all Nodal Supports
+			//List<Node> nodeList = new List<Node>();
+
+			rfModel.object_with_children[] nodalSupportObjWitheChildern = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODAL_SUPPORT);
+			nodalSupportObjWitheChildern = nodalSupportObjWitheChildern.ToList().Where(n => n.no != 0).ToArray();
+			IEnumerable<rfModel.nodal_support> nodalSupport = nodalSupportObjWitheChildern.Length >= 1 ? nodalSupportObjWitheChildern.ToList().Select(n => m_Model.get_nodal_support(n.no)) : new List<rfModel.nodal_support>();
+
+			List<int> nodalSupportNo = nodalSupport.ToList().Select(n => n.no).ToList();
+
+			if (nodalSupportNo.Count != 0)
+			{
+
+				filter = nodalSupportNo.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_NODAL_SUPPORT, no = n, parent_no = 0 }).ToArray();
+			}
+			else
+			{
+				BH.Engine.Base.Compute.RecordWarning("There no nodal Support that have been defined in RFEM6");
+				return resultList;
+			}
 
 
+			m_Model.calculate_all(true);
 
-                }
+			foreach (int lc in loadCaseIds)
+			{
 
-            }
+				nodes_support_forces_row[] res_all = m_Model.get_results_for_nodes_support_forces(
+					case_object_types.E_OBJECT_TYPE_LOAD_CASE,
+					lc,
+					filter
+					);
 
-            return resultList;
 
-        }
+				//Gather all ids of Nodes that are linked to a Nodal support
+				HashSet<int> idsOfAllNodesLikedToNodalSupport = res_all.Select(z => z.row.node_no).ToHashSet();
 
-    }
+				for (int i = 0; i < nodeIds.Count; i++)
+				{
+					//Is node id Linked to an id linked to Nodal Support
+					if (!idsOfAllNodesLikedToNodalSupport.Contains(nodeIds[i]))
+					{
+						BH.Engine.Base.Compute.RecordWarning(String.Format("There is no node id {0} linked to an Nodal Support", nodeIds[i]));
+						continue;
+					}
+					
+
+					var r = res_all.First(k => k.row.node_no.Equals(nodeIds[i]));
+
+					//var r = res_all[i];
+
+					double fxValue = r.row.support_force_p_x;
+					double fyValue = r.row.support_force_p_y;
+					double fzValue = r.row.support_force_p_z;
+					double mxValue = r.row.support_moment_m_x;
+					double myValue = r.row.support_moment_m_y;
+					double mzValue = r.row.support_moment_m_z;
+
+					NodeReaction nodeReaction = new NodeReaction(r.row.node_no, lc, 0, 0, oM.Geometry.Basis.XY, fxValue, fyValue, fzValue, mxValue, myValue, mzValue);
+					resultList.Add(nodeReaction);
+				}
+
+
+			}
+
+			return resultList;
+
+		}
+
+	}
 }
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
@@ -98,17 +98,24 @@ namespace BH.Adapter.RFEM6
                 foreach (int n in nodeIds)
                 {
 
-                    nodes_support_forces_row[] nodes_support_forces_rows = m_Model.get_results_for_nodes_support_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, lc, n);
+                    //nodes_support_forces_row[] nodes_support_forces_rows = m_Model.get_results_for_nodes_support_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, lc, n);
 
-                    var supportResultReaction = nodes_support_forces_rows.First().row;
-                    double fxValue = Double.Parse(supportResultReaction.support_force_p_x.value);
-                    double fyValue = Double.Parse(supportResultReaction.support_force_p_y.value);
-                    double fzValue = Double.Parse(supportResultReaction.support_force_p_z.value);
-                    double mxValue = Double.Parse(supportResultReaction.support_moment_m_x.value);
-                    double myValue = supportResultReaction.support_moment_m_y;
-                    double mzValue = supportResultReaction.support_moment_m_z;
+                    //var supportResultReaction = nodes_support_forces_rows.First().row;
+                    //double fxValue = Double.Parse(supportResultReaction.support_force_p_x.value);
+                    //double fyValue = Double.Parse(supportResultReaction.support_force_p_y.value);
+                    //double fzValue = Double.Parse(supportResultReaction.support_force_p_z.value);
+                    //double mxValue = Double.Parse(supportResultReaction.support_moment_m_x.value);
+                    //double myValue = supportResultReaction.support_moment_m_y;
+                    //double mzValue = supportResultReaction.support_moment_m_z;
 
-                    NodeReaction nodeReaction = new NodeReaction(n, lc, 0, 0, oM.Geometry.Basis.XY, fxValue, fyValue, fzValue, mxValue, myValue, mzValue);
+                    double fxValue = 0;
+					double fyValue = 0;
+					double fzValue = 0;
+					double mxValue = 0;
+					double myValue = 0;
+					double mzValue = 0;
+
+					NodeReaction nodeReaction = new NodeReaction(n, lc, 0, 0, oM.Geometry.Basis.XY, fxValue, fyValue, fzValue, mxValue, myValue, mzValue);
 
                     resultList.Add(nodeReaction);
 

--- a/RFEM6_Adapter/Comparers/RFEMSectionComparer.cs
+++ b/RFEM6_Adapter/Comparers/RFEMSectionComparer.cs
@@ -56,10 +56,10 @@ namespace BH.Adapter.RFEM6
                 Convert.AlterSectionName(section2);
             }
 
-            bool sectionTypeDoesMatch = String.Equals(section1.Name, section2.Name);
+            bool sectionNameDoesMatch = String.Equals(section1.Name, section2.Name);
             bool materialDoesMatch = String.Equals(section1.Material.Name, section2.Material.Name);
 
-            return false;
+            return sectionNameDoesMatch && materialDoesMatch;
 
         }
 

--- a/RFEM6_Adapter/RFEM6_Adapter.csproj
+++ b/RFEM6_Adapter/RFEM6_Adapter.csproj
@@ -17,7 +17,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dlubal.RFEMWebServiceLibrary" Version="6.5.5" />
+		<PackageReference Include="Dlubal.RFEMWebServiceLibrary" Version="6.7.6" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Private.ServiceModel" Version="4.10.0" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

After switching to RFEM 6.06.0013, the RFEM6_Toolkit stopped working.
The issue was resolved by updating the referenced Dlubal.RFEMWebServiceLibrary to 6.7.6.
The update of the package caused another issue, as the data structure necessary for pulling nodal results within the C# client had changed. So it was necessary to perform some alterations on that end as well.

Closes #98 

<!-- Add short description of what has been fixed -->

1. Bespoke package has been updated.
2. Reading of the nodal results has been updated.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File Folder](https://burohappold.sharepoint.com/:f:/s/BHoM/EuvuS4mATpxHoqQ4AUN2W3IBCX4KCpw7W6fncFRXpMA34A?e=gYmN1W)

Please test the update by: 

1. Open the RFEM File in RFEM6.06.0013 (Please this EXACT version!)
2. Open the GH file and try to pull the results. 
3. Compare the results in RFEM with the ones in GH. 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

1. Update of Dlubal.RFEMWebServiceLiabarary
4. Refactroing/Fixing the ExtractNodeReaction() method


