### PR TITLE
Reading BarResults From RFEM6

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -60,7 +60,7 @@ namespace RFEM_Toolkit_Test.Elements
 
 			BarResultRequest request = new BarResultRequest();
 
-			request.ResultType = BarResultType.BarStrain;
+			request.ResultType = BarResultType.BarDisplacement;
 			request.DivisionType = DivisionType.EvenlyDistributed;
 			request.Divisions = 3;
 			request.Cases = new List<Object> { 1 };

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -60,7 +60,7 @@ namespace RFEM_Toolkit_Test.Elements
 
 			BarResultRequest request = new BarResultRequest();
 
-			request.ResultType = BarResultType.BarDeformation;
+			request.ResultType = BarResultType.BarStrain;
 			request.DivisionType = DivisionType.ExtremeValues;
 			request.Divisions = 3;
 			request.Cases = new List<Object> { 1 };

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using BH.Adapter.RFEM6;
+using BH.Engine.Base;
+using BH.oM.Data.Requests;
+using BH.oM.Structure.MaterialFragments;
+using BH.Engine.Structure;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Geometry;
+using BH.oM.Structure.Elements;
+using BH.oM.Analytical.Elements;
+using BH.oM.Base;
+using BH.oM.Structure.Requests;
+
+namespace RFEM_Toolkit_Test.Elements
+{
+
+
+	public class BarResultTestClass
+
+	{
+
+		RFEM6Adapter adapter;
+
+		//[TearDown]
+		//public void TearDown()
+		//{
+		//	adapter.Wipeout();
+		//}
+
+		[OneTimeSetUp]
+		public void InitializeRFEM6Adapter()
+		{
+			adapter = new RFEM6Adapter(true);
+
+		}
+
+		[Test]
+		public void ReadResult()
+		{
+
+			BarResultRequest request = new BarResultRequest();
+
+			request.ResultType = BarResultType.BarStress;
+			request.DivisionType = DivisionType.ExtremeValues;
+			request.Divisions = 3;
+			request.Cases = new List<Object> { 1 };
+			request.Modes = new List<string>();
+			request.ObjectIds = new List<object> {1,2};
+
+			var obj = adapter.Pull(request);
+
+			obj.First();
+
+		}
+
+
+
+	}
+}
+

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -60,7 +60,7 @@ namespace RFEM_Toolkit_Test.Elements
 
 			BarResultRequest request = new BarResultRequest();
 
-			request.ResultType = BarResultType.BarDisplacement;
+			request.ResultType = BarResultType.BarForce;
 			request.DivisionType = DivisionType.EvenlyDistributed;
 			request.Divisions = 3;
 			request.Cases = new List<Object> { 1 };

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -60,8 +60,8 @@ namespace RFEM_Toolkit_Test.Elements
 
 			BarResultRequest request = new BarResultRequest();
 
-			request.ResultType = BarResultType.BarDisplacement;
-			request.DivisionType = DivisionType.EvenlyDistributed;
+			request.ResultType = BarResultType.BarDeformation;
+			request.DivisionType = DivisionType.ExtremeValues;
 			request.Divisions = 3;
 			request.Cases = new List<Object> { 1 };
 			request.Modes = new List<string>();

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -61,7 +61,7 @@ namespace RFEM_Toolkit_Test.Elements
 			BarResultRequest request = new BarResultRequest();
 
 			request.ResultType = BarResultType.BarDisplacement;
-			request.DivisionType = DivisionType.ExtremeValues;
+			request.DivisionType = DivisionType.EvenlyDistributed;
 			request.Divisions = 3;
 			request.Cases = new List<Object> { 1 };
 			request.Modes = new List<string>();

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -61,7 +61,7 @@ namespace RFEM_Toolkit_Test.Elements
 			BarResultRequest request = new BarResultRequest();
 
 			request.ResultType = BarResultType.BarStrain;
-			request.DivisionType = DivisionType.ExtremeValues;
+			request.DivisionType = DivisionType.EvenlyDistributed;
 			request.Divisions = 3;
 			request.Cases = new List<Object> { 1 };
 			request.Modes = new List<string>();

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -65,7 +65,8 @@ namespace RFEM_Toolkit_Test.Elements
 			request.Divisions = 3;
 			request.Cases = new List<Object> { 1 };
 			request.Modes = new List<string>();
-			request.ObjectIds = new List<object> {1,2};
+			request.ObjectIds = new List<object> {1};
+			//request.ObjectIds = new List<object> {1,2,3,4};
 
 			var obj = adapter.Pull(request);
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -60,7 +60,7 @@ namespace RFEM_Toolkit_Test.Elements
 
 			BarResultRequest request = new BarResultRequest();
 
-			request.ResultType = BarResultType.BarStress;
+			request.ResultType = BarResultType.BarDisplacement;
 			request.DivisionType = DivisionType.ExtremeValues;
 			request.Divisions = 3;
 			request.Cases = new List<Object> { 1 };

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -54,15 +54,6 @@ namespace BH.Adapter.RFEM6
 			//Warnings 
 			BH.Engine.Base.Compute.RecordWarning($"Divisions are set to {request.Divisions}. Division functionality has not been implemented yet in RFEM6_Toolkit. Currently, the number of divisions depends solely on what RFEM6 provides and can vary significantly based on the load type on the corresponding Bar/Member and the DivisionType.");
 
-			//if (request.ResultType == BarResultType.BarDisplacement)
-			//	BH.Engine.Base.Compute.RecordWarning("You are pulling displacement components. FX/FY/FZ will contain linear displacements (ux/uy/uz) and MX/MY/MZ will contain rotational displacements (rx/ry/rz), not forces/moments.");
-
-			//if (request.ResultType == BarResultType.BarDeformation)
-			//	BH.Engine.Base.Compute.RecordWarning("You are pulling bar deformation components. FX/FY/FZ will contain relative displacements (dx/dy/dz) and MX/MY/MZ will contain relative rotations (rx/ry/rz), not forces/moments.");
-
-			//else if (request.ResultType == BarResultType.BarStrain)
-			//	BH.Engine.Base.Compute.RecordWarning("You are pulling strain components. FX/FY/FZ will contain normal/shear strains (ex/vxy/vxz) and MX/MY/MZ will contain curvatures (kx/ky/kz), not forces/moments.");
-
 			//RFEM Specific Stuff
 			m_Model.use_detailed_member_results(true);
 
@@ -91,10 +82,10 @@ namespace BH.Adapter.RFEM6
 						barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
 						break;
 					case BarResultType.BarDisplacement:
-						barResults = m_Model.get_results_for_members_local_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
+						barResults = m_Model.get_results_for_members_global_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons);
 						break;
 					case BarResultType.BarDeformation:
-						barResults = m_Model.get_results_for_members_global_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons);
+						barResults = m_Model.get_results_for_members_local_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
 						break;
 					case BarResultType.BarStrain:
 						barResults = m_Model.get_results_for_members_strains(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -113,38 +113,32 @@ namespace BH.Adapter.RFEM6
 					{
 
 
-						if (member.First() is members_internal_forces_row)
+						int corrective = 2;
+						var extremeVal = member.SkipWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
+						extremeVal = extremeVal.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Total")).ToList();
+						
+						if (extremeVal?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
 						{
-							List<members_internal_forces_row> extremeValues = getExtremesForBarForces(member.Cast<members_internal_forces_row>().ToList());
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
+							extremeVal = extremeVal.Skip(2).ToList();
+							corrective = 0;
 						}
 
-						else if (member.First() is members_local_deformations_row)
+						foreach (var e in extremeVal)
 						{
-							List<members_local_deformations_row> extremeValues = getExtremesLocalDeformation(member.Cast<members_local_deformations_row>().ToList());
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
 
+							var location = Double.Parse(e.PropertyValue("row.location").ToString());
+							var memberNumber = Int32.Parse(e.PropertyValue("row.member_no").ToString());
+							var props = e.PropertyValue("row").GetType().GetProperties();
+							Dictionary<string, double> val = new[] {
+								(10-corrective, "x"), (12-corrective, "y"), (14-corrective, "z"),
+								(16-corrective, "rx"), (18-corrective, "ry"), (20-corrective, "rz")
+							}.ToDictionary(p => p.Item2, p => Double.Parse(
+								e.PropertyValue($"row.{props[p.Item1].Name}").ToString()
+							));
+
+							var bal = val.Values.ToList().FromRFEM(c, memberLength, location, memberNumber);
+							resultList.Add(bal);
 						}
-						else if (member.First() is members_global_deformations_row)
-						{
-							List<members_global_deformations_row> extremeValues = getExtremeGlobalDeformation(member.Cast<members_global_deformations_row>().ToList());
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
-
-						}
-						else if (member.First() is members_strains_row)
-						{
-							List<members_strains_row> extremeValues = getExtremeStrain(member.Cast<members_strains_row>().ToList());
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
-
-						}
-						else
-						{
-							List<members_internal_forces_row> extremeValues = getExtremesForBarForces(member.Cast<members_internal_forces_row>().ToList());
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
-
-						}
-
-
 
 
 						continue;
@@ -198,204 +192,204 @@ namespace BH.Adapter.RFEM6
 		}
 
 
-		private List<members_internal_forces_row> getExtremesForBarForces(List<members_internal_forces_row> membersInternalForces)
-		{
+//		private List<members_internal_forces_row> getExtremesForBarForces(List<members_internal_forces_row> membersInternalForces)
+//		{
 
-			var extremes_ = membersInternalForces.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-			   new
-			   {
-				   NMaxSection = membersInternalForces.First(),
-				   NMinSection = membersInternalForces.First(),
-				   ZMaxSection = membersInternalForces.First(),
-				   ZMinSection = membersInternalForces.First(),
-				   YMaxSection = membersInternalForces.First(),
-				   YMinSection = membersInternalForces.First(),
-				   MXMaxSection = membersInternalForces.First(),
-				   MXMinSection = membersInternalForces.First(),
-				   MYMaxSection = membersInternalForces.First(),
-				   MYMinSection = membersInternalForces.First(),
-				   MZMaxSection = membersInternalForces.First(),
-				   MZMinSection = membersInternalForces.First()
-			   },
-		(acc, m) => new
-		{
-			NMaxSection = m.row.internal_force_n > acc.NMaxSection.row.internal_force_n ? m : acc.NMaxSection,
-			NMinSection = m.row.internal_force_n < acc.NMinSection.row.internal_force_n ? m : acc.NMinSection,
-			ZMaxSection = m.row.internal_force_vz > acc.ZMaxSection.row.internal_force_vz ? m : acc.ZMaxSection,
-			ZMinSection = m.row.internal_force_vz < acc.ZMinSection.row.internal_force_vz ? m : acc.ZMinSection,
-			YMaxSection = m.row.internal_force_vy > acc.YMaxSection.row.internal_force_vy ? m : acc.YMaxSection,
-			YMinSection = m.row.internal_force_vy < acc.YMinSection.row.internal_force_vy ? m : acc.YMinSection,
-			MXMaxSection = m.row.internal_force_mt > acc.MXMaxSection.row.internal_force_mt ? m : acc.MXMaxSection,
-			MXMinSection = m.row.internal_force_mt < acc.MXMinSection.row.internal_force_mt ? m : acc.MXMinSection,
-			MYMaxSection = m.row.internal_force_my > acc.MYMaxSection.row.internal_force_my ? m : acc.MYMaxSection,
-			MYMinSection = m.row.internal_force_my < acc.MYMinSection.row.internal_force_my ? m : acc.MYMinSection,
-			MZMaxSection = m.row.internal_force_mz > acc.MZMaxSection.row.internal_force_mz ? m : acc.MZMaxSection,
-			MZMinSection = m.row.internal_force_mz < acc.MZMinSection.row.internal_force_mz ? m : acc.MZMinSection
-		}
-			);
+//			var extremes_ = membersInternalForces.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
+//			   new
+//			   {
+//				   NMaxSection = membersInternalForces.First(),
+//				   NMinSection = membersInternalForces.First(),
+//				   ZMaxSection = membersInternalForces.First(),
+//				   ZMinSection = membersInternalForces.First(),
+//				   YMaxSection = membersInternalForces.First(),
+//				   YMinSection = membersInternalForces.First(),
+//				   MXMaxSection = membersInternalForces.First(),
+//				   MXMinSection = membersInternalForces.First(),
+//				   MYMaxSection = membersInternalForces.First(),
+//				   MYMinSection = membersInternalForces.First(),
+//				   MZMaxSection = membersInternalForces.First(),
+//				   MZMinSection = membersInternalForces.First()
+//			   },
+//		(acc, m) => new
+//		{
+//			NMaxSection = m.row.internal_force_n > acc.NMaxSection.row.internal_force_n ? m : acc.NMaxSection,
+//			NMinSection = m.row.internal_force_n < acc.NMinSection.row.internal_force_n ? m : acc.NMinSection,
+//			ZMaxSection = m.row.internal_force_vz > acc.ZMaxSection.row.internal_force_vz ? m : acc.ZMaxSection,
+//			ZMinSection = m.row.internal_force_vz < acc.ZMinSection.row.internal_force_vz ? m : acc.ZMinSection,
+//			YMaxSection = m.row.internal_force_vy > acc.YMaxSection.row.internal_force_vy ? m : acc.YMaxSection,
+//			YMinSection = m.row.internal_force_vy < acc.YMinSection.row.internal_force_vy ? m : acc.YMinSection,
+//			MXMaxSection = m.row.internal_force_mt > acc.MXMaxSection.row.internal_force_mt ? m : acc.MXMaxSection,
+//			MXMinSection = m.row.internal_force_mt < acc.MXMinSection.row.internal_force_mt ? m : acc.MXMinSection,
+//			MYMaxSection = m.row.internal_force_my > acc.MYMaxSection.row.internal_force_my ? m : acc.MYMaxSection,
+//			MYMinSection = m.row.internal_force_my < acc.MYMinSection.row.internal_force_my ? m : acc.MYMinSection,
+//			MZMaxSection = m.row.internal_force_mz > acc.MZMaxSection.row.internal_force_mz ? m : acc.MZMaxSection,
+//			MZMinSection = m.row.internal_force_mz < acc.MZMinSection.row.internal_force_mz ? m : acc.MZMinSection
+//		}
+//			);
 
-			List<members_internal_forces_row> resultList = new List<members_internal_forces_row>() {
-	extremes_.NMaxSection, extremes_.NMinSection,
-	extremes_.YMaxSection, extremes_.YMinSection,
-	extremes_.ZMaxSection, extremes_.ZMinSection,
-	extremes_.MXMaxSection, extremes_.MXMinSection,
-	extremes_.MYMaxSection, extremes_.MYMinSection,
-	extremes_.MZMaxSection, extremes_.MZMinSection };
+//			List<members_internal_forces_row> resultList = new List<members_internal_forces_row>() {
+//	extremes_.NMaxSection, extremes_.NMinSection,
+//	extremes_.YMaxSection, extremes_.YMinSection,
+//	extremes_.ZMaxSection, extremes_.ZMinSection,
+//	extremes_.MXMaxSection, extremes_.MXMinSection,
+//	extremes_.MYMaxSection, extremes_.MYMinSection,
+//	extremes_.MZMaxSection, extremes_.MZMinSection };
 
-			return resultList;
+//			return resultList;
 
-		}
-		private List<members_local_deformations_row> getExtremesLocalDeformation(List<members_local_deformations_row> membersLocalDeformation)
-		{
+//		}
+//		private List<members_local_deformations_row> getExtremesLocalDeformation(List<members_local_deformations_row> membersLocalDeformation)
+//		{
 
-			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-			   new
-			   {
-				   dXMax = membersLocalDeformation.First(),
-				   dXMin = membersLocalDeformation.First(),
-				   dyMax = membersLocalDeformation.First(),
-				   dyMin = membersLocalDeformation.First(),
-				   dzMax = membersLocalDeformation.First(),
-				   dzMin = membersLocalDeformation.First(),
-				   rotXMax = membersLocalDeformation.First(),
-				   rotXMin = membersLocalDeformation.First(),
-				   rotYMax = membersLocalDeformation.First(),
-				   rotYMin = membersLocalDeformation.First(),
-				   rotZMax = membersLocalDeformation.First(),
-				   rotZMin = membersLocalDeformation.First(),
+//			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
+//			   new
+//			   {
+//				   dXMax = membersLocalDeformation.First(),
+//				   dXMin = membersLocalDeformation.First(),
+//				   dyMax = membersLocalDeformation.First(),
+//				   dyMin = membersLocalDeformation.First(),
+//				   dzMax = membersLocalDeformation.First(),
+//				   dzMin = membersLocalDeformation.First(),
+//				   rotXMax = membersLocalDeformation.First(),
+//				   rotXMin = membersLocalDeformation.First(),
+//				   rotYMax = membersLocalDeformation.First(),
+//				   rotYMin = membersLocalDeformation.First(),
+//				   rotZMax = membersLocalDeformation.First(),
+//				   rotZMin = membersLocalDeformation.First(),
 
-			   },
-(acc, m) => new
-{
-	dXMax = m.row.displacement_x > acc.dXMax.row.displacement_x ? m : acc.dXMax,
-	dXMin = m.row.displacement_x < acc.dXMin.row.displacement_x ? m : acc.dXMin,
-	dyMax = m.row.displacement_y > acc.dyMax.row.displacement_y ? m : acc.dyMax,
-	dyMin = m.row.displacement_y < acc.dyMin.row.displacement_y ? m : acc.dyMin,
-	dzMax = m.row.displacement_z > acc.dzMax.row.displacement_z ? m : acc.dzMax,
-	dzMin = m.row.displacement_z < acc.dzMin.row.displacement_z ? m : acc.dzMin,
-	rotXMax = m.row.rotation_x > acc.rotXMax.row.rotation_x ? m : acc.rotXMax,
-	rotXMin = m.row.rotation_x < acc.rotXMin.row.rotation_x ? m : acc.rotXMin,
-	rotYMax = m.row.rotation_y > acc.rotYMax.row.rotation_y ? m : acc.rotYMax,
-	rotYMin = m.row.rotation_y < acc.rotYMin.row.rotation_y ? m : acc.rotYMin,
-	rotZMax = m.row.rotation_z > acc.rotZMax.row.rotation_z ? m : acc.rotZMax,
-	rotZMin = m.row.rotation_z < acc.rotZMin.row.rotation_z ? m : acc.rotZMin
-}
-			);
+//			   },
+//(acc, m) => new
+//{
+//	dXMax = m.row.displacement_x > acc.dXMax.row.displacement_x ? m : acc.dXMax,
+//	dXMin = m.row.displacement_x < acc.dXMin.row.displacement_x ? m : acc.dXMin,
+//	dyMax = m.row.displacement_y > acc.dyMax.row.displacement_y ? m : acc.dyMax,
+//	dyMin = m.row.displacement_y < acc.dyMin.row.displacement_y ? m : acc.dyMin,
+//	dzMax = m.row.displacement_z > acc.dzMax.row.displacement_z ? m : acc.dzMax,
+//	dzMin = m.row.displacement_z < acc.dzMin.row.displacement_z ? m : acc.dzMin,
+//	rotXMax = m.row.rotation_x > acc.rotXMax.row.rotation_x ? m : acc.rotXMax,
+//	rotXMin = m.row.rotation_x < acc.rotXMin.row.rotation_x ? m : acc.rotXMin,
+//	rotYMax = m.row.rotation_y > acc.rotYMax.row.rotation_y ? m : acc.rotYMax,
+//	rotYMin = m.row.rotation_y < acc.rotYMin.row.rotation_y ? m : acc.rotYMin,
+//	rotZMax = m.row.rotation_z > acc.rotZMax.row.rotation_z ? m : acc.rotZMax,
+//	rotZMin = m.row.rotation_z < acc.rotZMin.row.rotation_z ? m : acc.rotZMin
+//}
+//			);
 
-			List<members_local_deformations_row> resultList = new List<members_local_deformations_row>() {
-	extremes_.dXMax, extremes_.dXMin,
-	extremes_.dyMax, extremes_.dyMin,
-	extremes_.dzMax, extremes_.dzMin,
-	extremes_.rotXMax, extremes_.rotXMin,
-	extremes_.rotYMax, extremes_.rotYMin,
-	extremes_.rotZMax, extremes_.rotZMin
-};
+//			List<members_local_deformations_row> resultList = new List<members_local_deformations_row>() {
+//	extremes_.dXMax, extremes_.dXMin,
+//	extremes_.dyMax, extremes_.dyMin,
+//	extremes_.dzMax, extremes_.dzMin,
+//	extremes_.rotXMax, extremes_.rotXMin,
+//	extremes_.rotYMax, extremes_.rotYMin,
+//	extremes_.rotZMax, extremes_.rotZMin
+//};
 
-			return resultList;
+//			return resultList;
 
-		}
+//		}
 
-		private List<members_global_deformations_row> getExtremeGlobalDeformation(List<members_global_deformations_row> membersLocalDeformation)
-		{
+//		private List<members_global_deformations_row> getExtremeGlobalDeformation(List<members_global_deformations_row> membersLocalDeformation)
+//		{
 
-			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-			   new
-			   {
-				   dXMax = membersLocalDeformation.First(),
-				   dXMin = membersLocalDeformation.First(),
-				   dyMax = membersLocalDeformation.First(),
-				   dyMin = membersLocalDeformation.First(),
-				   dzMax = membersLocalDeformation.First(),
-				   dzMin = membersLocalDeformation.First(),
-				   rotXMax = membersLocalDeformation.First(),
-				   rotXMin = membersLocalDeformation.First(),
-				   rotYMax = membersLocalDeformation.First(),
-				   rotYMin = membersLocalDeformation.First(),
-				   rotZMax = membersLocalDeformation.First(),
-				   rotZMin = membersLocalDeformation.First(),
+//			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
+//			   new
+//			   {
+//				   dXMax = membersLocalDeformation.First(),
+//				   dXMin = membersLocalDeformation.First(),
+//				   dyMax = membersLocalDeformation.First(),
+//				   dyMin = membersLocalDeformation.First(),
+//				   dzMax = membersLocalDeformation.First(),
+//				   dzMin = membersLocalDeformation.First(),
+//				   rotXMax = membersLocalDeformation.First(),
+//				   rotXMin = membersLocalDeformation.First(),
+//				   rotYMax = membersLocalDeformation.First(),
+//				   rotYMin = membersLocalDeformation.First(),
+//				   rotZMax = membersLocalDeformation.First(),
+//				   rotZMin = membersLocalDeformation.First(),
 
-			   },
-(acc, m) => new
-{
-	dXMax = m.row.displacement_x > acc.dXMax.row.displacement_x ? m : acc.dXMax,
-	dXMin = m.row.displacement_x < acc.dXMin.row.displacement_x ? m : acc.dXMin,
-	dyMax = m.row.displacement_y > acc.dyMax.row.displacement_y ? m : acc.dyMax,
-	dyMin = m.row.displacement_y < acc.dyMin.row.displacement_y ? m : acc.dyMin,
-	dzMax = m.row.displacement_z > acc.dzMax.row.displacement_z ? m : acc.dzMax,
-	dzMin = m.row.displacement_z < acc.dzMin.row.displacement_z ? m : acc.dzMin,
-	rotXMax = m.row.rotation_x > acc.rotXMax.row.rotation_x ? m : acc.rotXMax,
-	rotXMin = m.row.rotation_x < acc.rotXMin.row.rotation_x ? m : acc.rotXMin,
-	rotYMax = m.row.rotation_y > acc.rotYMax.row.rotation_y ? m : acc.rotYMax,
-	rotYMin = m.row.rotation_y < acc.rotYMin.row.rotation_y ? m : acc.rotYMin,
-	rotZMax = m.row.rotation_z > acc.rotZMax.row.rotation_z ? m : acc.rotZMax,
-	rotZMin = m.row.rotation_z < acc.rotZMin.row.rotation_z ? m : acc.rotZMin
-}
-			);
+//			   },
+//(acc, m) => new
+//{
+//	dXMax = m.row.displacement_x > acc.dXMax.row.displacement_x ? m : acc.dXMax,
+//	dXMin = m.row.displacement_x < acc.dXMin.row.displacement_x ? m : acc.dXMin,
+//	dyMax = m.row.displacement_y > acc.dyMax.row.displacement_y ? m : acc.dyMax,
+//	dyMin = m.row.displacement_y < acc.dyMin.row.displacement_y ? m : acc.dyMin,
+//	dzMax = m.row.displacement_z > acc.dzMax.row.displacement_z ? m : acc.dzMax,
+//	dzMin = m.row.displacement_z < acc.dzMin.row.displacement_z ? m : acc.dzMin,
+//	rotXMax = m.row.rotation_x > acc.rotXMax.row.rotation_x ? m : acc.rotXMax,
+//	rotXMin = m.row.rotation_x < acc.rotXMin.row.rotation_x ? m : acc.rotXMin,
+//	rotYMax = m.row.rotation_y > acc.rotYMax.row.rotation_y ? m : acc.rotYMax,
+//	rotYMin = m.row.rotation_y < acc.rotYMin.row.rotation_y ? m : acc.rotYMin,
+//	rotZMax = m.row.rotation_z > acc.rotZMax.row.rotation_z ? m : acc.rotZMax,
+//	rotZMin = m.row.rotation_z < acc.rotZMin.row.rotation_z ? m : acc.rotZMin
+//}
+//			);
 
-			List<members_global_deformations_row> resultList = new List<members_global_deformations_row>() {
-	extremes_.dXMax, extremes_.dXMin,
-	extremes_.dyMax, extremes_.dyMin,
-	extremes_.dzMax, extremes_.dzMin,
-	extremes_.rotXMax, extremes_.rotXMin,
-	extremes_.rotYMax, extremes_.rotYMin,
-	extremes_.rotZMax, extremes_.rotZMin
-};
+//			List<members_global_deformations_row> resultList = new List<members_global_deformations_row>() {
+//	extremes_.dXMax, extremes_.dXMin,
+//	extremes_.dyMax, extremes_.dyMin,
+//	extremes_.dzMax, extremes_.dzMin,
+//	extremes_.rotXMax, extremes_.rotXMin,
+//	extremes_.rotYMax, extremes_.rotYMin,
+//	extremes_.rotZMax, extremes_.rotZMin
+//};
 
-			return resultList;
+//			return resultList;
 
-		}
-
-
-		private List<members_strains_row> getExtremeStrain(List<members_strains_row> membersLocalDeformation)
-		{
-
-			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-			   new
-			   {
-				   exMax = membersLocalDeformation.First(),
-				   exMin = membersLocalDeformation.First(),
-				   yxyMax = membersLocalDeformation.First(),
-				   yxyMin = membersLocalDeformation.First(),
-				   yxzMax = membersLocalDeformation.First(),
-				   yxzMin = membersLocalDeformation.First(),
-				   kxMax = membersLocalDeformation.First(),
-				   kxMin = membersLocalDeformation.First(),
-				   kyMax = membersLocalDeformation.First(),
-				   kyMin = membersLocalDeformation.First(),
-				   kzMax = membersLocalDeformation.First(),
-				   kzMin = membersLocalDeformation.First()
+//		}
 
 
-			   },
-(acc, m) => new
-{
-	exMax = m.row.strain_eps_x > acc.exMax.row.strain_eps_x ? m : acc.exMax,
-	exMin = m.row.strain_eps_x < acc.exMin.row.strain_eps_x ? m : acc.exMin,
-	yxyMax = m.row.strain_gamma_xy > acc.yxyMax.row.strain_gamma_xy ? m : acc.yxyMax,
-	yxyMin = m.row.strain_gamma_xy < acc.yxyMin.row.strain_gamma_xy ? m : acc.yxyMin,
-	yxzMax = m.row.strain_gamma_xz > acc.yxzMax.row.strain_gamma_xz ? m : acc.yxzMax,
-	yxzMin = m.row.strain_gamma_xz < acc.yxzMin.row.strain_gamma_xz ? m : acc.yxzMin,
-	kxMax = m.row.strain_kappa_x > acc.kxMax.row.strain_kappa_x ? m : acc.kxMax,
-	kxMin = m.row.strain_kappa_x < acc.kxMin.row.strain_kappa_x ? m : acc.kxMin,
-	kyMax = m.row.strain_kappa_y > acc.kyMax.row.strain_kappa_y ? m : acc.kyMax,
-	kyMin = m.row.strain_kappa_y < acc.kyMin.row.strain_kappa_y ? m : acc.kyMin,
-	kzMax = m.row.strain_kappa_z > acc.kzMax.row.strain_kappa_z ? m : acc.kzMax,
-	kzMin = m.row.strain_kappa_z < acc.kzMin.row.strain_kappa_z ? m : acc.kzMin
-}
-			);
+//		private List<members_strains_row> getExtremeStrain(List<members_strains_row> membersLocalDeformation)
+//		{
 
-			List<members_strains_row> resultList = new List<members_strains_row>() {
-   extremes_.exMax, extremes_.exMin,
-   extremes_.yxyMax, extremes_.yxyMin,
-   extremes_.yxzMax, extremes_.yxzMin,
-   extremes_.kxMax, extremes_.kxMin,
-   extremes_.kyMax, extremes_.kyMin,
-   extremes_.kzMax, extremes_.kzMin
-};
+//			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
+//			   new
+//			   {
+//				   exMax = membersLocalDeformation.First(),
+//				   exMin = membersLocalDeformation.First(),
+//				   yxyMax = membersLocalDeformation.First(),
+//				   yxyMin = membersLocalDeformation.First(),
+//				   yxzMax = membersLocalDeformation.First(),
+//				   yxzMin = membersLocalDeformation.First(),
+//				   kxMax = membersLocalDeformation.First(),
+//				   kxMin = membersLocalDeformation.First(),
+//				   kyMax = membersLocalDeformation.First(),
+//				   kyMin = membersLocalDeformation.First(),
+//				   kzMax = membersLocalDeformation.First(),
+//				   kzMin = membersLocalDeformation.First()
 
-			return resultList;
 
-		}
+//			   },
+//(acc, m) => new
+//{
+//	exMax = m.row.strain_eps_x > acc.exMax.row.strain_eps_x ? m : acc.exMax,
+//	exMin = m.row.strain_eps_x < acc.exMin.row.strain_eps_x ? m : acc.exMin,
+//	yxyMax = m.row.strain_gamma_xy > acc.yxyMax.row.strain_gamma_xy ? m : acc.yxyMax,
+//	yxyMin = m.row.strain_gamma_xy < acc.yxyMin.row.strain_gamma_xy ? m : acc.yxyMin,
+//	yxzMax = m.row.strain_gamma_xz > acc.yxzMax.row.strain_gamma_xz ? m : acc.yxzMax,
+//	yxzMin = m.row.strain_gamma_xz < acc.yxzMin.row.strain_gamma_xz ? m : acc.yxzMin,
+//	kxMax = m.row.strain_kappa_x > acc.kxMax.row.strain_kappa_x ? m : acc.kxMax,
+//	kxMin = m.row.strain_kappa_x < acc.kxMin.row.strain_kappa_x ? m : acc.kxMin,
+//	kyMax = m.row.strain_kappa_y > acc.kyMax.row.strain_kappa_y ? m : acc.kyMax,
+//	kyMin = m.row.strain_kappa_y < acc.kyMin.row.strain_kappa_y ? m : acc.kyMin,
+//	kzMax = m.row.strain_kappa_z > acc.kzMax.row.strain_kappa_z ? m : acc.kzMax,
+//	kzMin = m.row.strain_kappa_z < acc.kzMin.row.strain_kappa_z ? m : acc.kzMin
+//}
+//			);
+
+//			List<members_strains_row> resultList = new List<members_strains_row>() {
+//   extremes_.exMax, extremes_.exMin,
+//   extremes_.yxyMax, extremes_.yxyMin,
+//   extremes_.yxzMax, extremes_.yxzMin,
+//   extremes_.kxMax, extremes_.kxMin,
+//   extremes_.kyMax, extremes_.kyMin,
+//   extremes_.kzMax, extremes_.kzMin
+//};
+
+//			return resultList;
+
+//		}
 
 
 	}

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using BH.oM.Adapter;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Constraints;
+
+using rfModel = Dlubal.WS.Rfem6.Model;
+using BH.oM.Adapters.RFEM6;
+using BH.oM.Structure.Loads;
+using Dlubal.WS.Rfem6.Model;
+using System.Xml.Linq;
+using BH.Engine.Base;
+using BH.oM.Analytical.Results;
+using BH.oM.Structure.Requests;
+using BH.oM.Structure.Results;
+using System.Configuration;
+
+namespace BH.Adapter.RFEM6
+{
+	public partial class RFEM6Adapter
+	{
+
+		public IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
+		{
+
+			m_Model.use_detailed_member_results(true);
+			// Loading of Member And LoadCase Ids
+			List<int> memberIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
+			List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
+			
+			// Definition of Object Locations for Members
+			object_location[] filters = memberIds.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_MEMBER, no = n, parent_no = 0 }).ToArray();
+
+
+			List<IResult> allInternalForces = new List<IResult>();
+			foreach (int c in loadCaseIds)
+			{
+				//Get Results bar forces for specific LC
+				members_internal_forces_row[] resultForMemberInternalForces = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+				
+
+
+				//Grouping of Internal Forces grouped by Member No
+				var memberInternalForceGroup = resultForMemberInternalForces.GroupBy(r => r.row.member_no);
+
+				foreach (IGrouping<int, members_internal_forces_row> group in memberInternalForceGroup)
+				{
+					if (group.Key == 0) continue;
+					//If we are looing for extreme values
+					if (request.DivisionType == DivisionType.ExtremeValues)
+					{
+						var extremeRow = group.Where(g=>g.description.ToUpper().Contains("EXTREMES")).First();
+						allInternalForces.Add(extremeRow.FromRFEM(c, request.DivisionType));
+						continue;
+					}
+
+
+					foreach (var g in group) {
+
+						
+
+						//Likely unnecessary
+						if (g.description.ToUpper().Contains("EXTREMES")) break ;
+
+						allInternalForces.Add(g.FromRFEM(c, request.DivisionType));
+						
+					}
+
+				}
+
+			}
+
+			return allInternalForces;
+
+		}
+
+	}
+}
+
+

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -66,11 +66,7 @@ namespace BH.Adapter.RFEM6
 
 			foreach (int c in loadCaseIds)
 			{
-				////Get Results bar forces for specific LC
-				//members_internal_forces_row[] resultForMemberInternalForces = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
 
-
-				//INotifyPropertyChanged[] barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
 				INotifyPropertyChanged[] barResults = new INotifyPropertyChanged[1];
 
 				switch (request.ResultType)
@@ -100,7 +96,7 @@ namespace BH.Adapter.RFEM6
 				}
 
 				//Grouping of Internal Forces grouped by Member No
-				var memberInternalForceGroup = barResults.GroupBy(r =>Int32.Parse(r.PropertyValue("row.member_no").ToString()));
+				var memberInternalForceGroup = barResults.GroupBy(r => Int32.Parse(r.PropertyValue("row.member_no").ToString()));
 
 				foreach (IGrouping<int, INotifyPropertyChanged> member in memberInternalForceGroup)
 				{
@@ -123,19 +119,19 @@ namespace BH.Adapter.RFEM6
 							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
 						}
 
-						else if (member.First() is members_local_deformations)
+						else if (member.First() is members_local_deformations_row)
 						{
 							List<members_local_deformations_row> extremeValues = getExtremesLocalDeformation(member.Cast<members_local_deformations_row>().ToList());
 							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
 
 						}
-						else if (member.First() is members_global_deformations)
+						else if (member.First() is members_global_deformations_row)
 						{
 							List<members_global_deformations_row> extremeValues = getExtremeGlobalDeformation(member.Cast<members_global_deformations_row>().ToList());
 							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
 
 						}
-						else if (member.First() is members_strains)
+						else if (member.First() is members_strains_row)
 						{
 							List<members_strains_row> extremeValues = getExtremeStrain(member.Cast<members_strains_row>().ToList());
 							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
@@ -148,27 +144,15 @@ namespace BH.Adapter.RFEM6
 
 						}
 
-						//List<members_internal_forces_row> extremeValues = getExtremesForBarForces(member.ToList());
 
-						//foreach (var e in extremeValues)
-						//{
-						//	//e.FromRFEM(c,memberLength).
-						//	allInternalForces.Add(e.FromRFEM(c, memberLength));
-						//}
 
 
 						continue;
 					}
-					//}
 
 					else
 					{
 
-						//foreach (var memberSegment in member)
-						//{
-
-						//Ignoring Rows after Extremes
-						//if (memberSegment.PropertyValue("description").ToString().Contains("Extremes")) { break; }
 						var memberList = member.ToList();
 						memberList = member.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -137,21 +137,24 @@ namespace BH.Adapter.RFEM6
 
 					}
 
-					int corrective = 2; // important do to enable processing of Deformations due to the |u|
-										//if (request.ResultType == BarResultType.BarDisplacement)
+					int corrective = (request.ResultType == BarResultType.BarDisplacement || request.ResultType == BarResultType.BarDeformation) ? 0 : 2; 
+					// important do to enable processing of Deformations due to the |u|
 					if (memberSegmentValues?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
 					{
 						memberSegmentValues = memberSegmentValues.Skip(2).ToList();
-						corrective = 0;
+						//corrective = 0;
 					}
 
 					//Conversion for every segment of member
 					foreach (var e in memberSegmentValues)
 					{
 
+
 						var location = Double.Parse(e.PropertyValue("row.location").ToString());
 						var memberNumber = Int32.Parse(e.PropertyValue("row.member_no").ToString());
 						var props = e.PropertyValue("row").GetType().GetProperties();
+						List<int> accesList = new List<int>() { 10 - corrective, 12 - corrective, 14 - corrective, 16 - corrective, 18 - corrective, 20 - corrective };
+						var accessedlist = accesList.Select(a => props.ToList()[a]);
 						Dictionary<string, double> val = new[] {
 							(10-corrective, "x"), (12-corrective, "y"), (14-corrective, "z"),
 							(16-corrective, "rx"), (18-corrective, "ry"), (20-corrective, "rz")

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -52,13 +52,15 @@ namespace BH.Adapter.RFEM6
 
 			BH.Engine.Base.Compute.RecordWarning($"Divisions are set to {request.Divisions}. Division functionality has not been implemented yet in RFEM6_Toolkit. Currently, the number of divisions depends solely on what RFEM6 provides and can vary significantly based on the load type on the corresponding Bar/Member and the DivisionType.");
 
+			//RFEM Specific Stuff
 			m_Model.use_detailed_member_results(true);
+
 			// Loading of Member And LoadCase Ids
 			List<int> memberIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
 			List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
 
 			// Definition of Object Locations for Members
-			object_location[] filters = memberIds.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_MEMBER, no = n, parent_no = 0 }).ToArray();
+			object_location[] objectLocatioons = memberIds.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_MEMBER, no = n, parent_no = 0 }).ToArray();
 
 			//ResultList
 			List<IResult> resultList = new List<IResult>();
@@ -67,22 +69,23 @@ namespace BH.Adapter.RFEM6
 			foreach (int c in loadCaseIds)
 			{
 
+				//Loading resulst from RFEM
 				INotifyPropertyChanged[] barResults = new INotifyPropertyChanged[1];
 
 				switch (request.ResultType)
 				{
 
 					case BarResultType.BarForce:
-						barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+						barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
 						break;
 					case BarResultType.BarDisplacement:
-						barResults = m_Model.get_results_for_members_local_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+						barResults = m_Model.get_results_for_members_local_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
 						break;
 					case BarResultType.BarDeformation:
-						barResults = m_Model.get_results_for_members_global_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters);
+						barResults = m_Model.get_results_for_members_global_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons);
 						break;
 					case BarResultType.BarStrain:
-						barResults = m_Model.get_results_for_members_strains(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+						barResults = m_Model.get_results_for_members_strains(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
 						break;
 					case BarResultType.BarStress:
 
@@ -90,7 +93,7 @@ namespace BH.Adapter.RFEM6
 						return null;
 
 					default:
-						barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+						barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
 						break;
 
 				}
@@ -98,6 +101,8 @@ namespace BH.Adapter.RFEM6
 				//Grouping of Internal Forces grouped by Member No
 				var memberInternalForceGroup = barResults.GroupBy(r => Int32.Parse(r.PropertyValue("row.member_no").ToString()));
 
+
+				//Results processing memberwise
 				foreach (IGrouping<int, INotifyPropertyChanged> member in memberInternalForceGroup)
 				{
 					//Ignore Results that do now have a valied ID
@@ -107,290 +112,55 @@ namespace BH.Adapter.RFEM6
 					String lengthAsString = member.ToList()[0].PropertyValue("row.specification").ToString().Split(new[] { "L : ", " m" }, StringSplitOptions.None)[1];
 					double memberLength = double.Parse(lengthAsString, CultureInfo.InvariantCulture);// Member Length in SI unit m;
 
+					var memberSegmentValues = member.ToList();
 
 					//If we are looking for exterme Values
 					if (request.DivisionType == DivisionType.ExtremeValues)
 					{
 
 
-						int corrective = 2;
-						var extremeVal = member.SkipWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
-						extremeVal = extremeVal.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Total")).ToList();
-						
-						if (extremeVal?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
-						{
-							extremeVal = extremeVal.Skip(2).ToList();
-							corrective = 0;
-						}
+						memberSegmentValues = member.SkipWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
+						memberSegmentValues = memberSegmentValues.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Total")).ToList();
 
-						foreach (var e in extremeVal)
-						{
-
-							var location = Double.Parse(e.PropertyValue("row.location").ToString());
-							var memberNumber = Int32.Parse(e.PropertyValue("row.member_no").ToString());
-							var props = e.PropertyValue("row").GetType().GetProperties();
-							Dictionary<string, double> val = new[] {
-								(10-corrective, "x"), (12-corrective, "y"), (14-corrective, "z"),
-								(16-corrective, "rx"), (18-corrective, "ry"), (20-corrective, "rz")
-							}.ToDictionary(p => p.Item2, p => Double.Parse(
-								e.PropertyValue($"row.{props[p.Item1].Name}").ToString()
-							));
-
-							var bal = val.Values.ToList().FromRFEM(c, memberLength, location, memberNumber);
-							resultList.Add(bal);
-						}
-
-
-						continue;
 					}
-
+					
 					else
 					{
+						memberSegmentValues = memberSegmentValues.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
 
-						var memberList = member.ToList();
-						memberList = member.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
-
-						if (memberList.First() is members_internal_forces_row)
-						{
-							List<members_internal_forces_row> extremeValues = memberList.Cast<members_internal_forces_row>().ToList();
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
-						}
-
-						else if (memberList.First() is members_local_deformations_row)
-						{
-							List<members_local_deformations_row> extremeValues = memberList.Cast<members_local_deformations_row>().ToList();
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
-
-						}
-						else if (memberList.First() is members_global_deformations_row)
-						{
-							List<members_global_deformations_row> extremeValues = memberList.Cast<members_global_deformations_row>().ToList();
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
-
-						}
-						else if (memberList.First() is members_strains_row)
-						{
-							List<members_strains_row> extremeValues = memberList.Cast<members_strains_row>().ToList();
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
-
-						}
-						else
-						{
-							List<members_internal_forces_row> extremeValues = memberList.Cast<members_internal_forces_row>().ToList();
-							resultList.AddRange(extremeValues.Select(e => e.FromRFEM(c, memberLength)));
-
-						}
-
-						//}
 					}
-				}
 
+					int corrective = 2; // important do to enable processing of Deformations due to the |u|
+					if (memberSegmentValues?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
+					{
+						memberSegmentValues = memberSegmentValues.Skip(2).ToList();
+						corrective = 0;
+					}
+
+					//Conversion for every segment of member
+					foreach (var e in memberSegmentValues)
+					{
+
+						var location = Double.Parse(e.PropertyValue("row.location").ToString());
+						var memberNumber = Int32.Parse(e.PropertyValue("row.member_no").ToString());
+						var props = e.PropertyValue("row").GetType().GetProperties();
+						Dictionary<string, double> val = new[] {
+							(10-corrective, "x"), (12-corrective, "y"), (14-corrective, "z"),
+							(16-corrective, "rx"), (18-corrective, "ry"), (20-corrective, "rz")
+						}.ToDictionary(p => p.Item2, p => Double.Parse(
+							e.PropertyValue($"row.{props[p.Item1].Name}").ToString()
+						));
+
+						var bal = val.Values.ToList().FromRFEM(c, memberLength, location, memberNumber);
+						resultList.Add(bal);
+					}
+
+				}
 			}
 
 			return resultList;
 
 		}
-
-
-//		private List<members_internal_forces_row> getExtremesForBarForces(List<members_internal_forces_row> membersInternalForces)
-//		{
-
-//			var extremes_ = membersInternalForces.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-//			   new
-//			   {
-//				   NMaxSection = membersInternalForces.First(),
-//				   NMinSection = membersInternalForces.First(),
-//				   ZMaxSection = membersInternalForces.First(),
-//				   ZMinSection = membersInternalForces.First(),
-//				   YMaxSection = membersInternalForces.First(),
-//				   YMinSection = membersInternalForces.First(),
-//				   MXMaxSection = membersInternalForces.First(),
-//				   MXMinSection = membersInternalForces.First(),
-//				   MYMaxSection = membersInternalForces.First(),
-//				   MYMinSection = membersInternalForces.First(),
-//				   MZMaxSection = membersInternalForces.First(),
-//				   MZMinSection = membersInternalForces.First()
-//			   },
-//		(acc, m) => new
-//		{
-//			NMaxSection = m.row.internal_force_n > acc.NMaxSection.row.internal_force_n ? m : acc.NMaxSection,
-//			NMinSection = m.row.internal_force_n < acc.NMinSection.row.internal_force_n ? m : acc.NMinSection,
-//			ZMaxSection = m.row.internal_force_vz > acc.ZMaxSection.row.internal_force_vz ? m : acc.ZMaxSection,
-//			ZMinSection = m.row.internal_force_vz < acc.ZMinSection.row.internal_force_vz ? m : acc.ZMinSection,
-//			YMaxSection = m.row.internal_force_vy > acc.YMaxSection.row.internal_force_vy ? m : acc.YMaxSection,
-//			YMinSection = m.row.internal_force_vy < acc.YMinSection.row.internal_force_vy ? m : acc.YMinSection,
-//			MXMaxSection = m.row.internal_force_mt > acc.MXMaxSection.row.internal_force_mt ? m : acc.MXMaxSection,
-//			MXMinSection = m.row.internal_force_mt < acc.MXMinSection.row.internal_force_mt ? m : acc.MXMinSection,
-//			MYMaxSection = m.row.internal_force_my > acc.MYMaxSection.row.internal_force_my ? m : acc.MYMaxSection,
-//			MYMinSection = m.row.internal_force_my < acc.MYMinSection.row.internal_force_my ? m : acc.MYMinSection,
-//			MZMaxSection = m.row.internal_force_mz > acc.MZMaxSection.row.internal_force_mz ? m : acc.MZMaxSection,
-//			MZMinSection = m.row.internal_force_mz < acc.MZMinSection.row.internal_force_mz ? m : acc.MZMinSection
-//		}
-//			);
-
-//			List<members_internal_forces_row> resultList = new List<members_internal_forces_row>() {
-//	extremes_.NMaxSection, extremes_.NMinSection,
-//	extremes_.YMaxSection, extremes_.YMinSection,
-//	extremes_.ZMaxSection, extremes_.ZMinSection,
-//	extremes_.MXMaxSection, extremes_.MXMinSection,
-//	extremes_.MYMaxSection, extremes_.MYMinSection,
-//	extremes_.MZMaxSection, extremes_.MZMinSection };
-
-//			return resultList;
-
-//		}
-//		private List<members_local_deformations_row> getExtremesLocalDeformation(List<members_local_deformations_row> membersLocalDeformation)
-//		{
-
-//			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-//			   new
-//			   {
-//				   dXMax = membersLocalDeformation.First(),
-//				   dXMin = membersLocalDeformation.First(),
-//				   dyMax = membersLocalDeformation.First(),
-//				   dyMin = membersLocalDeformation.First(),
-//				   dzMax = membersLocalDeformation.First(),
-//				   dzMin = membersLocalDeformation.First(),
-//				   rotXMax = membersLocalDeformation.First(),
-//				   rotXMin = membersLocalDeformation.First(),
-//				   rotYMax = membersLocalDeformation.First(),
-//				   rotYMin = membersLocalDeformation.First(),
-//				   rotZMax = membersLocalDeformation.First(),
-//				   rotZMin = membersLocalDeformation.First(),
-
-//			   },
-//(acc, m) => new
-//{
-//	dXMax = m.row.displacement_x > acc.dXMax.row.displacement_x ? m : acc.dXMax,
-//	dXMin = m.row.displacement_x < acc.dXMin.row.displacement_x ? m : acc.dXMin,
-//	dyMax = m.row.displacement_y > acc.dyMax.row.displacement_y ? m : acc.dyMax,
-//	dyMin = m.row.displacement_y < acc.dyMin.row.displacement_y ? m : acc.dyMin,
-//	dzMax = m.row.displacement_z > acc.dzMax.row.displacement_z ? m : acc.dzMax,
-//	dzMin = m.row.displacement_z < acc.dzMin.row.displacement_z ? m : acc.dzMin,
-//	rotXMax = m.row.rotation_x > acc.rotXMax.row.rotation_x ? m : acc.rotXMax,
-//	rotXMin = m.row.rotation_x < acc.rotXMin.row.rotation_x ? m : acc.rotXMin,
-//	rotYMax = m.row.rotation_y > acc.rotYMax.row.rotation_y ? m : acc.rotYMax,
-//	rotYMin = m.row.rotation_y < acc.rotYMin.row.rotation_y ? m : acc.rotYMin,
-//	rotZMax = m.row.rotation_z > acc.rotZMax.row.rotation_z ? m : acc.rotZMax,
-//	rotZMin = m.row.rotation_z < acc.rotZMin.row.rotation_z ? m : acc.rotZMin
-//}
-//			);
-
-//			List<members_local_deformations_row> resultList = new List<members_local_deformations_row>() {
-//	extremes_.dXMax, extremes_.dXMin,
-//	extremes_.dyMax, extremes_.dyMin,
-//	extremes_.dzMax, extremes_.dzMin,
-//	extremes_.rotXMax, extremes_.rotXMin,
-//	extremes_.rotYMax, extremes_.rotYMin,
-//	extremes_.rotZMax, extremes_.rotZMin
-//};
-
-//			return resultList;
-
-//		}
-
-//		private List<members_global_deformations_row> getExtremeGlobalDeformation(List<members_global_deformations_row> membersLocalDeformation)
-//		{
-
-//			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-//			   new
-//			   {
-//				   dXMax = membersLocalDeformation.First(),
-//				   dXMin = membersLocalDeformation.First(),
-//				   dyMax = membersLocalDeformation.First(),
-//				   dyMin = membersLocalDeformation.First(),
-//				   dzMax = membersLocalDeformation.First(),
-//				   dzMin = membersLocalDeformation.First(),
-//				   rotXMax = membersLocalDeformation.First(),
-//				   rotXMin = membersLocalDeformation.First(),
-//				   rotYMax = membersLocalDeformation.First(),
-//				   rotYMin = membersLocalDeformation.First(),
-//				   rotZMax = membersLocalDeformation.First(),
-//				   rotZMin = membersLocalDeformation.First(),
-
-//			   },
-//(acc, m) => new
-//{
-//	dXMax = m.row.displacement_x > acc.dXMax.row.displacement_x ? m : acc.dXMax,
-//	dXMin = m.row.displacement_x < acc.dXMin.row.displacement_x ? m : acc.dXMin,
-//	dyMax = m.row.displacement_y > acc.dyMax.row.displacement_y ? m : acc.dyMax,
-//	dyMin = m.row.displacement_y < acc.dyMin.row.displacement_y ? m : acc.dyMin,
-//	dzMax = m.row.displacement_z > acc.dzMax.row.displacement_z ? m : acc.dzMax,
-//	dzMin = m.row.displacement_z < acc.dzMin.row.displacement_z ? m : acc.dzMin,
-//	rotXMax = m.row.rotation_x > acc.rotXMax.row.rotation_x ? m : acc.rotXMax,
-//	rotXMin = m.row.rotation_x < acc.rotXMin.row.rotation_x ? m : acc.rotXMin,
-//	rotYMax = m.row.rotation_y > acc.rotYMax.row.rotation_y ? m : acc.rotYMax,
-//	rotYMin = m.row.rotation_y < acc.rotYMin.row.rotation_y ? m : acc.rotYMin,
-//	rotZMax = m.row.rotation_z > acc.rotZMax.row.rotation_z ? m : acc.rotZMax,
-//	rotZMin = m.row.rotation_z < acc.rotZMin.row.rotation_z ? m : acc.rotZMin
-//}
-//			);
-
-//			List<members_global_deformations_row> resultList = new List<members_global_deformations_row>() {
-//	extremes_.dXMax, extremes_.dXMin,
-//	extremes_.dyMax, extremes_.dyMin,
-//	extremes_.dzMax, extremes_.dzMin,
-//	extremes_.rotXMax, extremes_.rotXMin,
-//	extremes_.rotYMax, extremes_.rotYMin,
-//	extremes_.rotZMax, extremes_.rotZMin
-//};
-
-//			return resultList;
-
-//		}
-
-
-//		private List<members_strains_row> getExtremeStrain(List<members_strains_row> membersLocalDeformation)
-//		{
-
-//			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-//			   new
-//			   {
-//				   exMax = membersLocalDeformation.First(),
-//				   exMin = membersLocalDeformation.First(),
-//				   yxyMax = membersLocalDeformation.First(),
-//				   yxyMin = membersLocalDeformation.First(),
-//				   yxzMax = membersLocalDeformation.First(),
-//				   yxzMin = membersLocalDeformation.First(),
-//				   kxMax = membersLocalDeformation.First(),
-//				   kxMin = membersLocalDeformation.First(),
-//				   kyMax = membersLocalDeformation.First(),
-//				   kyMin = membersLocalDeformation.First(),
-//				   kzMax = membersLocalDeformation.First(),
-//				   kzMin = membersLocalDeformation.First()
-
-
-//			   },
-//(acc, m) => new
-//{
-//	exMax = m.row.strain_eps_x > acc.exMax.row.strain_eps_x ? m : acc.exMax,
-//	exMin = m.row.strain_eps_x < acc.exMin.row.strain_eps_x ? m : acc.exMin,
-//	yxyMax = m.row.strain_gamma_xy > acc.yxyMax.row.strain_gamma_xy ? m : acc.yxyMax,
-//	yxyMin = m.row.strain_gamma_xy < acc.yxyMin.row.strain_gamma_xy ? m : acc.yxyMin,
-//	yxzMax = m.row.strain_gamma_xz > acc.yxzMax.row.strain_gamma_xz ? m : acc.yxzMax,
-//	yxzMin = m.row.strain_gamma_xz < acc.yxzMin.row.strain_gamma_xz ? m : acc.yxzMin,
-//	kxMax = m.row.strain_kappa_x > acc.kxMax.row.strain_kappa_x ? m : acc.kxMax,
-//	kxMin = m.row.strain_kappa_x < acc.kxMin.row.strain_kappa_x ? m : acc.kxMin,
-//	kyMax = m.row.strain_kappa_y > acc.kyMax.row.strain_kappa_y ? m : acc.kyMax,
-//	kyMin = m.row.strain_kappa_y < acc.kyMin.row.strain_kappa_y ? m : acc.kyMin,
-//	kzMax = m.row.strain_kappa_z > acc.kzMax.row.strain_kappa_z ? m : acc.kzMax,
-//	kzMin = m.row.strain_kappa_z < acc.kzMin.row.strain_kappa_z ? m : acc.kzMin
-//}
-//			);
-
-//			List<members_strains_row> resultList = new List<members_strains_row>() {
-//   extremes_.exMax, extremes_.exMin,
-//   extremes_.yxyMax, extremes_.yxyMin,
-//   extremes_.yxzMax, extremes_.yxzMin,
-//   extremes_.kxMax, extremes_.kxMin,
-//   extremes_.kyMax, extremes_.kyMin,
-//   extremes_.kzMax, extremes_.kzMin
-//};
-
-//			return resultList;
-
-//		}
-
 
 	}
 }

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -138,8 +138,8 @@ namespace BH.Adapter.RFEM6
 					}
 
 					int corrective = 2; // important do to enable processing of Deformations due to the |u|
-					if (request.ResultType == BarResultType.BarDisplacement || request.ResultType == BarResultType.BarDeformation)
-					//if (memberSegmentValues?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
+										//if (request.ResultType == BarResultType.BarDisplacement)
+					if (memberSegmentValues?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
 					{
 						memberSegmentValues = memberSegmentValues.Skip(2).ToList();
 						corrective = 0;

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -54,14 +54,14 @@ namespace BH.Adapter.RFEM6
 			//Warnings 
 			BH.Engine.Base.Compute.RecordWarning($"Divisions are set to {request.Divisions}. Division functionality has not been implemented yet in RFEM6_Toolkit. Currently, the number of divisions depends solely on what RFEM6 provides and can vary significantly based on the load type on the corresponding Bar/Member and the DivisionType.");
 
-			if (request.ResultType == BarResultType.BarDisplacement)
-				BH.Engine.Base.Compute.RecordWarning("You are pulling displacement components. FX/FY/FZ will contain linear displacements (ux/uy/uz) and MX/MY/MZ will contain rotational displacements (rx/ry/rz), not forces/moments.");
+			//if (request.ResultType == BarResultType.BarDisplacement)
+			//	BH.Engine.Base.Compute.RecordWarning("You are pulling displacement components. FX/FY/FZ will contain linear displacements (ux/uy/uz) and MX/MY/MZ will contain rotational displacements (rx/ry/rz), not forces/moments.");
 
-			if (request.ResultType == BarResultType.BarDeformation)
-				BH.Engine.Base.Compute.RecordWarning("You are pulling bar deformation components. FX/FY/FZ will contain relative displacements (dx/dy/dz) and MX/MY/MZ will contain relative rotations (rx/ry/rz), not forces/moments.");
+			//if (request.ResultType == BarResultType.BarDeformation)
+			//	BH.Engine.Base.Compute.RecordWarning("You are pulling bar deformation components. FX/FY/FZ will contain relative displacements (dx/dy/dz) and MX/MY/MZ will contain relative rotations (rx/ry/rz), not forces/moments.");
 
-			else if (request.ResultType == BarResultType.BarStrain)
-				BH.Engine.Base.Compute.RecordWarning("You are pulling strain components. FX/FY/FZ will contain normal/shear strains (ex/vxy/vxz) and MX/MY/MZ will contain curvatures (kx/ky/kz), not forces/moments.");
+			//else if (request.ResultType == BarResultType.BarStrain)
+			//	BH.Engine.Base.Compute.RecordWarning("You are pulling strain components. FX/FY/FZ will contain normal/shear strains (ex/vxy/vxz) and MX/MY/MZ will contain curvatures (kx/ky/kz), not forces/moments.");
 
 			//RFEM Specific Stuff
 			m_Model.use_detailed_member_results(true);
@@ -162,8 +162,8 @@ namespace BH.Adapter.RFEM6
 							e.PropertyValue($"row.{props[p.Item1].Name}").ToString()
 						));
 
-						var bal = val.Values.ToList().FromRFEM(c, memberLength, location, memberNumber);
-						resultList.Add(bal);
+						var result = val.Values.ToList().FromRFEM(c, memberLength, location, memberNumber,request.ResultType);
+						resultList.Add(result);
 					}
 
 				}

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -79,133 +79,51 @@ namespace BH.Adapter.RFEM6
 					String lengthAsString = member.First().row.specification.Split(new[] { "L : ", " m" }, StringSplitOptions.None)[1];
 					double memberLength = double.Parse(lengthAsString, CultureInfo.InvariantCulture);// Member Length in SI unit m;
 
+
+					//If 
 					if (request.DivisionType == DivisionType.ExtremeValues)
 					{
 
-
-						var extremes = new Dictionary<string, (double value, members_internal_forces_row row)>();
-
-						foreach (var memberSegment in member)
-						{
-
-							if (memberSegment.description.Contains("Extremes")) break;
-
-						//	//local method updating dictinary
-						//	void UpdateExtreme(string key, double value, members_internal_forces_row row, Boolean isNegative)
-						//	{
-
-						//		//bool valueGetsUpdated = (!extremes.ContainsKey(key) || isNegative )? value < extremes[key].value : value > extremes[key].value;
-						//		bool valueGetsUpdated = !extremes.ContainsKey(key) || (isNegative ? value < extremes[key].value : value > extremes[key].value);
-
-						//		if ((!extremes.ContainsKey(key) || valueGetsUpdated) & !isNegative)
-						//		{
-						//			extremes[key] = (value, row);
-						//		}
-
-						//	}
-
-						//	UpdateExtreme("FX_Pos", memberSegment.row.internal_force_n, memberSegment, false);
-						//	UpdateExtreme("FY_Pos", memberSegment.row.internal_force_vy, memberSegment, false);
-						//	UpdateExtreme("FZ_Pos", memberSegment.row.internal_force_vz, memberSegment, false);
-						//	UpdateExtreme("MX_Pos", memberSegment.row.internal_force_mt, memberSegment, false);
-						//	UpdateExtreme("MY_Pos", memberSegment.row.internal_force_my, memberSegment, false);
-						//	UpdateExtreme("MZ_Pos", memberSegment.row.internal_force_mz, memberSegment, false);
-						//	UpdateExtreme("FX_Neg", memberSegment.row.internal_force_n, memberSegment, false);
-						//	UpdateExtreme("FY_Neg", memberSegment.row.internal_force_vy, memberSegment, false);
-						//	UpdateExtreme("FZ_Neg", memberSegment.row.internal_force_vz, memberSegment, false);
-						//	UpdateExtreme("MX_Neg", memberSegment.row.internal_force_mt, memberSegment, false);
-						//	UpdateExtreme("MY_Neg", memberSegment.row.internal_force_my, memberSegment, false);
-						//	UpdateExtreme("MZ_Neg", memberSegment.row.internal_force_mz, memberSegment, false);
-						//}
-
-
-						//var extremeValues = new List<members_internal_forces_row>
-						//						{
-						//							extremes["FX_Pos"].row,
-						//							extremes["FX_Pos"].row,
-						//							extremes["FZ_Pos"].row,
-						//							extremes["MX_Pos"].row,
-						//							extremes["MY_Pos"].row,
-						//							extremes["MZ_Pos"].row,
-						//							extremes["FX_Neg"].row,
-						//							extremes["FX_Neg"].row,
-						//							extremes["FZ_Neg"].row,
-						//							extremes["MX_Neg"].row,
-						//							extremes["MY_Neg"].row,
-						//							extremes["MZ_Neg"].row
-						//						};
-
-						//foreach (var e in extremeValues)
-						//{
-						//	//e.FromRFEM(c,memberLength).
-						//	allInternalForces.Add(e.FromRFEM(c, memberLength));
-						//}
-
-
-						var extremes_ = member.ToList().TakeWhile(v=>v.description.Contains("Extreme")).Aggregate(
+						var extremes_ = member.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
 			   new
 			   {
-				   NMax = double.MinValue,
-				   NMaxSection = member.ToList()[0],
-				   NMin = double.MaxValue,
-				   NMinSection = member.ToList()[0],
-				   ZMax = double.MinValue,
-				   ZMaxSection = member.ToList()[0],
-				   ZMin = double.MaxValue,
-				   ZMinSection = member.ToList()[0],
-				   YMax = double.MinValue,
-				   YMaxSection = member.ToList()[0],
-				   YMin = double.MaxValue,
-				   YMinSection = member.ToList()[0],
-				   MXMax = double.MinValue,
-				   MXMaxSection = member.ToList()[0],
-				   MXMin = double.MaxValue,
-				   MXMinSection = member.ToList()[0],
-				   MYMax = double.MinValue,
-				   MYMaxSection = member.ToList()[0],
-				   MYMin = double.MaxValue,
-				   MYMinSection = member.ToList()[0],
-				   MZMax = double.MinValue,
-				   MZMaxSection = member.ToList()[0],
-				   MZMin = double.MaxValue,
-				   MZMinSection = member.ToList()[0]
+				   NMaxSection = member.First(),
+				   NMinSection = member.First(),
+				   ZMaxSection = member.First(),
+				   ZMinSection = member.First(),
+				   YMaxSection = member.First(),
+				   YMinSection = member.First(),
+				   MXMaxSection = member.First(),
+				   MXMinSection = member.First(),
+				   MYMaxSection = member.First(),
+				   MYMinSection = member.First(),
+				   MZMaxSection = member.First(),
+				   MZMinSection = member.First()
 			   },
 		(acc, m) => new
 		{
-			NMax = Math.Max(acc.NMax, m.row.internal_force_n),
-			NMaxSection = m.row.internal_force_n > acc.NMax ? m : acc.NMaxSection,
-			NMin = Math.Min(acc.NMin, m.row.internal_force_n),
-			NMinSection = m.row.internal_force_n < acc.NMin ? m : acc.NMinSection,
-			ZMax = Math.Max(acc.ZMax, m.row.internal_force_vz),
-			ZMaxSection = m.row.internal_force_vz > acc.ZMax ? m : acc.ZMaxSection,
-			ZMin = Math.Min(acc.ZMin, m.row.internal_force_vz),
-			ZMinSection = m.row.internal_force_vz < acc.ZMin ? m : acc.ZMinSection,
-			YMax = Math.Max(acc.YMax, m.row.internal_force_vy),
-			YMaxSection = m.row.internal_force_vy > acc.YMax ? m : acc.YMaxSection,
-			YMin = Math.Min(acc.YMin, m.row.internal_force_vy),
-			YMinSection = m.row.internal_force_vy < acc.YMin ? m : acc.YMinSection,
-			MXMax = Math.Max(acc.MXMax, m.row.internal_force_mt),
-			MXMaxSection = m.row.internal_force_mt > acc.MXMax ? m : acc.MXMaxSection,
-			MXMin = Math.Min(acc.MXMin, m.row.internal_force_mt),
-			MXMinSection = m.row.internal_force_mt < acc.MXMin ? m : acc.MXMinSection,
-			MYMax = Math.Max(acc.MYMax, m.row.internal_force_my),
-			MYMaxSection = m.row.internal_force_my > acc.MYMax ? m : acc.MYMaxSection,
-			MYMin = Math.Min(acc.MYMin, m.row.internal_force_my),
-			MYMinSection = m.row.internal_force_my < acc.MYMin ? m : acc.MYMinSection,
-			MZMax = Math.Max(acc.MZMax, m.row.internal_force_mz),
-			MZMaxSection = m.row.internal_force_mz > acc.MZMax ? m : acc.MZMaxSection,
-			MZMin = Math.Min(acc.MZMin, m.row.internal_force_mz),
-			MZMinSection = m.row.internal_force_mz < acc.MZMin ? m : acc.MZMinSection
+			NMaxSection = m.row.internal_force_n > acc.NMaxSection.row.internal_force_n ? m : acc.NMaxSection,
+			NMinSection = m.row.internal_force_n < acc.NMinSection.row.internal_force_n ? m : acc.NMinSection,
+			ZMaxSection = m.row.internal_force_vz > acc.ZMaxSection.row.internal_force_vz ? m : acc.ZMaxSection,
+			ZMinSection = m.row.internal_force_vz < acc.ZMinSection.row.internal_force_vz ? m : acc.ZMinSection,
+			YMaxSection = m.row.internal_force_vy > acc.YMaxSection.row.internal_force_vy ? m : acc.YMaxSection,
+			YMinSection = m.row.internal_force_vy < acc.YMinSection.row.internal_force_vy ? m : acc.YMinSection,
+			MXMaxSection = m.row.internal_force_mt > acc.MXMaxSection.row.internal_force_mt ? m : acc.MXMaxSection,
+			MXMinSection = m.row.internal_force_mt < acc.MXMinSection.row.internal_force_mt ? m : acc.MXMinSection,
+			MYMaxSection = m.row.internal_force_my > acc.MYMaxSection.row.internal_force_my ? m : acc.MYMaxSection,
+			MYMinSection = m.row.internal_force_my < acc.MYMinSection.row.internal_force_my ? m : acc.MYMinSection,
+			MZMaxSection = m.row.internal_force_mz > acc.MZMaxSection.row.internal_force_mz ? m : acc.MZMaxSection,
+			MZMinSection = m.row.internal_force_mz < acc.MZMinSection.row.internal_force_mz ? m : acc.MZMinSection
 		}
 			);
 
-						extremeValues = new List<members_internal_forces_row>() {
-   extremes_.MXMaxSection, extremes_.NMinSection,
-   extremes_.ZMaxSection, extremes_.ZMinSection,
-   extremes_.YMaxSection, extremes_.YMinSection,
-   extremes_.MXMaxSection, extremes_.MXMinSection,
-   extremes_.MYMaxSection, extremes_.MYMinSection,
-   extremes_.MZMaxSection, extremes_.MZMinSection
+						List<members_internal_forces_row> extremeValues = new List<members_internal_forces_row>() {
+	extremes_.NMaxSection, extremes_.NMinSection,
+	extremes_.ZMaxSection, extremes_.ZMinSection,
+	extremes_.YMaxSection, extremes_.YMinSection,
+	extremes_.MXMaxSection, extremes_.MXMinSection,
+	extremes_.MYMaxSection, extremes_.MYMinSection,
+	extremes_.MZMaxSection, extremes_.MZMinSection
 };
 						foreach (var e in extremeValues)
 						{
@@ -216,6 +134,7 @@ namespace BH.Adapter.RFEM6
 
 						continue;
 					}
+					//}
 
 					else
 					{

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -39,6 +39,8 @@ using BH.oM.Structure.Requests;
 using BH.oM.Structure.Results;
 using System.Configuration;
 using System.Globalization;
+using System.ComponentModel;
+using System.Linq.Expressions;
 
 namespace BH.Adapter.RFEM6
 {
@@ -48,7 +50,7 @@ namespace BH.Adapter.RFEM6
 		public IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
 		{
 
-			BH.Engine.Base.Compute.RecordWarning($"Divisions are set to {request.Divisions}. Division functionality has not been implemented yet in RFEM6_Toolkit. Currently, the number of divisions depends solely on what RFEM6 provides and can vary significantly based on the load type on the corresponding Bar/Member.");
+			BH.Engine.Base.Compute.RecordWarning($"Divisions are set to {request.Divisions}. Division functionality has not been implemented yet in RFEM6_Toolkit. Currently, the number of divisions depends solely on what RFEM6 provides and can vary significantly based on the load type on the corresponding Bar/Member and the DivisionType.");
 
 			m_Model.use_detailed_member_results(true);
 			// Loading of Member And LoadCase Ids
@@ -65,7 +67,36 @@ namespace BH.Adapter.RFEM6
 				//Get Results bar forces for specific LC
 				members_internal_forces_row[] resultForMemberInternalForces = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
 
+				///////////////////////////////////////////playground
 
+				INotifyPropertyChanged[] barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+
+				switch (request.ResultType)
+				{
+
+					case BarResultType.BarForce:
+						barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+						break;
+					case BarResultType.BarDisplacement:
+						barResults = m_Model.get_results_for_members_local_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+						break;
+					case BarResultType.BarDeformation:
+						barResults = m_Model.get_results_for_members_global_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters);
+						break;
+					case BarResultType.BarStrain:
+						barResults = m_Model.get_results_for_members_strains(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+						break;
+					case BarResultType.BarStress:
+
+						BH.Engine.Base.Compute.RecordError("The Pull of Bar Stresses has not been developed Yet");
+						return null;
+						break;
+
+					default:
+						barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, filters, axes_type.MEMBER_AXES);
+						break;
+
+				}
 
 				//Grouping of Internal Forces grouped by Member No
 				var memberInternalForceGroup = resultForMemberInternalForces.GroupBy(r => r.row.member_no);
@@ -84,47 +115,8 @@ namespace BH.Adapter.RFEM6
 					if (request.DivisionType == DivisionType.ExtremeValues)
 					{
 
-						var extremes_ = member.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
-			   new
-			   {
-				   NMaxSection = member.First(),
-				   NMinSection = member.First(),
-				   ZMaxSection = member.First(),
-				   ZMinSection = member.First(),
-				   YMaxSection = member.First(),
-				   YMinSection = member.First(),
-				   MXMaxSection = member.First(),
-				   MXMinSection = member.First(),
-				   MYMaxSection = member.First(),
-				   MYMinSection = member.First(),
-				   MZMaxSection = member.First(),
-				   MZMinSection = member.First()
-			   },
-		(acc, m) => new
-		{
-			NMaxSection = m.row.internal_force_n > acc.NMaxSection.row.internal_force_n ? m : acc.NMaxSection,
-			NMinSection = m.row.internal_force_n < acc.NMinSection.row.internal_force_n ? m : acc.NMinSection,
-			ZMaxSection = m.row.internal_force_vz > acc.ZMaxSection.row.internal_force_vz ? m : acc.ZMaxSection,
-			ZMinSection = m.row.internal_force_vz < acc.ZMinSection.row.internal_force_vz ? m : acc.ZMinSection,
-			YMaxSection = m.row.internal_force_vy > acc.YMaxSection.row.internal_force_vy ? m : acc.YMaxSection,
-			YMinSection = m.row.internal_force_vy < acc.YMinSection.row.internal_force_vy ? m : acc.YMinSection,
-			MXMaxSection = m.row.internal_force_mt > acc.MXMaxSection.row.internal_force_mt ? m : acc.MXMaxSection,
-			MXMinSection = m.row.internal_force_mt < acc.MXMinSection.row.internal_force_mt ? m : acc.MXMinSection,
-			MYMaxSection = m.row.internal_force_my > acc.MYMaxSection.row.internal_force_my ? m : acc.MYMaxSection,
-			MYMinSection = m.row.internal_force_my < acc.MYMinSection.row.internal_force_my ? m : acc.MYMinSection,
-			MZMaxSection = m.row.internal_force_mz > acc.MZMaxSection.row.internal_force_mz ? m : acc.MZMaxSection,
-			MZMinSection = m.row.internal_force_mz < acc.MZMinSection.row.internal_force_mz ? m : acc.MZMinSection
-		}
-			);
+						List<members_internal_forces_row> extremeValues = getExtremesForBarForces(member.ToList());
 
-						List<members_internal_forces_row> extremeValues = new List<members_internal_forces_row>() {
-	extremes_.NMaxSection, extremes_.NMinSection,
-	extremes_.ZMaxSection, extremes_.ZMinSection,
-	extremes_.YMaxSection, extremes_.YMinSection,
-	extremes_.MXMaxSection, extremes_.MXMinSection,
-	extremes_.MYMaxSection, extremes_.MYMinSection,
-	extremes_.MZMaxSection, extremes_.MZMinSection
-};
 						foreach (var e in extremeValues)
 						{
 							//e.FromRFEM(c,memberLength).
@@ -153,6 +145,104 @@ namespace BH.Adapter.RFEM6
 			}
 
 			return allInternalForces;
+
+		}
+
+
+		private List<members_internal_forces_row> getExtremesForBarForces(List<members_internal_forces_row> membersInternalForces)
+		{
+
+			var extremes_ = membersInternalForces.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
+			   new
+			   {
+				   NMaxSection = membersInternalForces.First(),
+				   NMinSection = membersInternalForces.First(),
+				   ZMaxSection = membersInternalForces.First(),
+				   ZMinSection = membersInternalForces.First(),
+				   YMaxSection = membersInternalForces.First(),
+				   YMinSection = membersInternalForces.First(),
+				   MXMaxSection = membersInternalForces.First(),
+				   MXMinSection = membersInternalForces.First(),
+				   MYMaxSection = membersInternalForces.First(),
+				   MYMinSection = membersInternalForces.First(),
+				   MZMaxSection = membersInternalForces.First(),
+				   MZMinSection = membersInternalForces.First()
+			   },
+		(acc, m) => new
+		{
+			NMaxSection = m.row.internal_force_n > acc.NMaxSection.row.internal_force_n ? m : acc.NMaxSection,
+			NMinSection = m.row.internal_force_n < acc.NMinSection.row.internal_force_n ? m : acc.NMinSection,
+			ZMaxSection = m.row.internal_force_vz > acc.ZMaxSection.row.internal_force_vz ? m : acc.ZMaxSection,
+			ZMinSection = m.row.internal_force_vz < acc.ZMinSection.row.internal_force_vz ? m : acc.ZMinSection,
+			YMaxSection = m.row.internal_force_vy > acc.YMaxSection.row.internal_force_vy ? m : acc.YMaxSection,
+			YMinSection = m.row.internal_force_vy < acc.YMinSection.row.internal_force_vy ? m : acc.YMinSection,
+			MXMaxSection = m.row.internal_force_mt > acc.MXMaxSection.row.internal_force_mt ? m : acc.MXMaxSection,
+			MXMinSection = m.row.internal_force_mt < acc.MXMinSection.row.internal_force_mt ? m : acc.MXMinSection,
+			MYMaxSection = m.row.internal_force_my > acc.MYMaxSection.row.internal_force_my ? m : acc.MYMaxSection,
+			MYMinSection = m.row.internal_force_my < acc.MYMinSection.row.internal_force_my ? m : acc.MYMinSection,
+			MZMaxSection = m.row.internal_force_mz > acc.MZMaxSection.row.internal_force_mz ? m : acc.MZMaxSection,
+			MZMinSection = m.row.internal_force_mz < acc.MZMinSection.row.internal_force_mz ? m : acc.MZMinSection
+		}
+			);
+
+			List<members_internal_forces_row> resultList = new List<members_internal_forces_row>() {
+	extremes_.NMaxSection, extremes_.NMinSection,
+	extremes_.YMaxSection, extremes_.YMinSection,
+	extremes_.ZMaxSection, extremes_.ZMinSection,
+	extremes_.MXMaxSection, extremes_.MXMinSection,
+	extremes_.MYMaxSection, extremes_.MYMinSection,
+	extremes_.MZMaxSection, extremes_.MZMinSection };
+
+			return resultList;
+
+		}
+		private List<members_local_deformations_row> getExtremesForBarForces(List<members_local_deformations_row> membersLocalDeformation)
+		{
+
+			var extremes_ = membersLocalDeformation.ToList().TakeWhile(v => !v.description.Contains("Extreme")).Aggregate(
+			   new
+			   {
+				   dXMax = membersLocalDeformation.First(),
+				   dXMin = membersLocalDeformation.First(),
+				   dyMax = membersLocalDeformation.First(),
+				   dyMin = membersLocalDeformation.First(),
+				   dzMax = membersLocalDeformation.First(),
+				   dzMin = membersLocalDeformation.First(),
+				   rotXMax = membersLocalDeformation.First(),
+				   rotXMin = membersLocalDeformation.First(),
+				   rotYMax = membersLocalDeformation.First(),
+				   rotYMin = membersLocalDeformation.First(),
+				   rotZMax = membersLocalDeformation.First(),
+				   rotZMin = membersLocalDeformation.First(),
+
+			   },
+(acc, m) => new
+{
+	dXMax = m.row.displacement_x > acc.dXMax.row.displacement_x ? m : acc.dXMax,
+	dXMin = m.row.displacement_x < acc.dXMin.row.displacement_x ? m : acc.dXMin,
+	dyMax = m.row.displacement_y > acc.dyMax.row.displacement_y ? m : acc.dyMax,
+	dyMin = m.row.displacement_y < acc.dyMin.row.displacement_y ? m : acc.dyMin,
+	dzMax = m.row.displacement_z > acc.dzMax.row.displacement_z ? m : acc.dzMax,
+	dzMin = m.row.displacement_z < acc.dzMin.row.displacement_z ? m : acc.dzMin,
+	rotXMax = m.row.rotation_x > acc.rotXMax.row.rotation_x ? m : acc.rotXMax,
+	rotXMin = m.row.rotation_x < acc.rotXMin.row.rotation_x ? m : acc.rotXMin,
+	rotYMax = m.row.rotation_y > acc.rotYMax.row.rotation_y ? m : acc.rotYMax,
+	rotYMin = m.row.rotation_y < acc.rotYMin.row.rotation_y ? m : acc.rotYMin,
+	rotZMax = m.row.rotation_z > acc.rotZMax.row.rotation_z ? m : acc.rotZMax,
+	rotZMin = m.row.rotation_z < acc.rotZMin.row.rotation_z ? m : acc.rotZMin
+}
+			);
+
+			List<members_local_deformations_row> resultList = new List<members_local_deformations_row>() {
+	extremes_.dXMax, extremes_.dXMin,
+	extremes_.dyMax, extremes_.dyMin,
+	extremes_.dzMax, extremes_.dzMin,
+	extremes_.rotXMax, extremes_.rotXMin,
+	extremes_.rotYMax, extremes_.rotYMin,
+	extremes_.rotZMax, extremes_.rotZMin
+};
+
+			return resultList;
 
 		}
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
@@ -78,11 +78,6 @@ namespace BH.Adapter.RFEM6
 			List<IResult> resultList = new List<IResult>();
 			object_location[] filter = null;
 
-			//If no node ids are provided, then we will extract the results for all nodes
-
-			//get all Nodal Supports
-			//List<Node> nodeList = new List<Node>();
-
 			rfModel.object_with_children[] nodalSupportObjWitheChildern = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODAL_SUPPORT);
 			nodalSupportObjWitheChildern = nodalSupportObjWitheChildern.ToList().Where(n => n.no != 0).ToArray();
 			IEnumerable<rfModel.nodal_support> nodalSupport = nodalSupportObjWitheChildern.Length >= 1 ? nodalSupportObjWitheChildern.ToList().Select(n => m_Model.get_nodal_support(n.no)) : new List<rfModel.nodal_support>();
@@ -127,8 +122,6 @@ namespace BH.Adapter.RFEM6
 					
 
 					var r = res_all.First(k => k.row.node_no.Equals(nodeIds[i]));
-
-					//var r = res_all[i];
 
 					double fxValue = r.row.support_force_p_x;
 					double fyValue = r.row.support_force_p_y;

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -58,6 +58,35 @@ namespace BH.Adapter.RFEM6
 			return barForce;
 		}
 
+		public static IResult FromRFEM(this members_local_deformations_row memberInternalForces, int lc, double memberLength)
+		{
+
+			var f = memberInternalForces.row;
+
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 2), 10, f.displacement_x, f.displacement_y, f.displacement_z, f.displacement_x, f.displacement_y, f.displacement_z);
+
+			return barForce;
+		}
+
+		public static IResult FromRFEM(this members_global_deformations_row memberInternalForces, int lc, double memberLength)
+		{
+
+			var f = memberInternalForces.row;
+
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 2), 10, f.displacement_x, f.displacement_y, f.displacement_z, f.displacement_x, f.displacement_y, f.displacement_z);
+
+			return barForce;
+		}
+
+		public static IResult FromRFEM(this members_strains_row memberInternalForces, int lc, double memberLength)
+		{
+
+			var f = memberInternalForces.row;
+
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 2), 10, f.strain_eps_x, f.strain_gamma_xy, f.strain_gamma_xz, f.strain_kappa_x, f.strain_kappa_y, f.strain_kappa_y);
+
+			return barForce;
+		}
 
 
 	}

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -53,7 +53,7 @@ namespace BH.Adapter.RFEM6
 
 			var f = memberInternalForces.row;
 
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 2), 10, f.internal_force_v, f.internal_force_vy, f.internal_force_vz, f.internal_force_mt, f.internal_force_my, f.internal_force_mz);
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 4), 10, f.internal_force_v, f.internal_force_vy, f.internal_force_vz, f.internal_force_mt, f.internal_force_my, f.internal_force_mz);
 
 			return barForce;
 		}
@@ -63,7 +63,7 @@ namespace BH.Adapter.RFEM6
 
 			var f = memberInternalForces.row;
 
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 2), 10, f.displacement_x, f.displacement_y, f.displacement_z, f.displacement_x, f.displacement_y, f.displacement_z);
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 4), 10, f.displacement_x, f.displacement_y, f.displacement_z, f.rotation_x, f.rotation_y, f.rotation_z);
 
 			return barForce;
 		}
@@ -73,7 +73,7 @@ namespace BH.Adapter.RFEM6
 
 			var f = memberInternalForces.row;
 
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 2), 10, f.displacement_x, f.displacement_y, f.displacement_z, f.displacement_x, f.displacement_y, f.displacement_z);
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 4), 10, f.displacement_x, f.displacement_y, f.displacement_z, f.rotation_x, f.rotation_y, f.rotation_z);
 
 			return barForce;
 		}
@@ -83,7 +83,7 @@ namespace BH.Adapter.RFEM6
 
 			var f = memberInternalForces.row;
 
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 2), 10, f.strain_eps_x, f.strain_gamma_xy, f.strain_gamma_xz, f.strain_kappa_x, f.strain_kappa_y, f.strain_kappa_y);
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 4), 10, f.strain_eps_x, f.strain_gamma_xy, f.strain_gamma_xz, f.strain_kappa_x, f.strain_kappa_y, f.strain_kappa_y);
 
 			return barForce;
 		}

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using BH.oM.Adapter;
+using BH.oM.Structure.Elements;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.RFEM6;
+
+using rfModel = Dlubal.WS.Rfem6.Model;
+using BH.oM.Structure.Loads;
+using BH.oM.Geometry;
+using BH.Engine.Spatial;
+using Dlubal.WS.Rfem6.Model;
+using BH.oM.Adapters.RFEM6.BHoMDataStructure.SupportDatastrures;
+using BH.oM.Adapters.RFEM6.Fragments.Enums;
+using System.Linq.Expressions;
+using System.Diagnostics;
+using BH.oM.Base;
+using BH.oM.Analytical.Results;
+using BH.oM.Structure.Results;
+using BH.oM.Structure.Requests;
+
+namespace BH.Adapter.RFEM6
+{
+    public static partial class Convert
+    {
+
+        public static IResult FromRFEM(this members_internal_forces_row memberInternalForces, int lc ,DivisionType divisionType)
+        {
+
+            var f = memberInternalForces.row;
+            
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, memberInternalForces.no, 10, f.internal_force_v, f.internal_force_vy, f.internal_force_vz,f.internal_force_mt, f.internal_force_my, f.internal_force_mz);
+
+			return barForce;
+        }
+
+     
+
+    }
+}
+
+

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -45,22 +45,22 @@ using BH.oM.Structure.Requests;
 
 namespace BH.Adapter.RFEM6
 {
-    public static partial class Convert
-    {
+	public static partial class Convert
+	{
 
-        public static IResult FromRFEM(this members_internal_forces_row memberInternalForces, int lc ,DivisionType divisionType)
-        {
+		public static IResult FromRFEM(this members_internal_forces_row memberInternalForces, int lc, double memberLength)
+		{
 
-            var f = memberInternalForces.row;
-            
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, memberInternalForces.no, 10, f.internal_force_v, f.internal_force_vy, f.internal_force_vz,f.internal_force_mt, f.internal_force_my, f.internal_force_mz);
+			var f = memberInternalForces.row;
+
+			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 2), 10, f.internal_force_v, f.internal_force_vy, f.internal_force_vz, f.internal_force_mt, f.internal_force_my, f.internal_force_mz);
 
 			return barForce;
-        }
+		}
 
-     
 
-    }
+
+	}
 }
 
 

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -47,63 +47,13 @@ namespace BH.Adapter.RFEM6
 {
 	public static partial class Convert
 	{
-
-		public static IResult FromRFEM(this members_internal_forces_row memberInternalForces, int lc, double memberLength)
+		public static IResult FromRFEM(this List<double> val, int lc, double memberLength, double location, int memberNumber)
 		{
-
-			var f = memberInternalForces.row;
-
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 4), 10, f.internal_force_v, f.internal_force_vy, f.internal_force_vz, f.internal_force_mt, f.internal_force_my, f.internal_force_mz);
-
-			return barForce;
-		}
-
-		public static IResult FromRFEM(this members_local_deformations_row memberInternalForces, int lc, double memberLength)
-		{
-
-			var f = memberInternalForces.row;
-
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 4), 10, f.displacement_x, f.displacement_y, f.displacement_z, f.rotation_x, f.rotation_y, f.rotation_z);
-
-			return barForce;
-		}
-
-		public static IResult FromRFEM(this members_global_deformations_row memberInternalForces, int lc, double memberLength)
-		{
-
-			var f = memberInternalForces.row;
-
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 4), 10, f.displacement_x, f.displacement_y, f.displacement_z, f.rotation_x, f.rotation_y, f.rotation_z);
-
-			return barForce;
-		}
-
-		public static IResult FromRFEM(this members_strains_row memberInternalForces, int lc, double memberLength)
-		{
-
-			var f = memberInternalForces.row;
-
-			BarForce barForce = new BarForce(memberInternalForces.row.member_no, lc, -1, -1, Math.Round((double)memberInternalForces.row.location / memberLength, 4), 10, f.strain_eps_x, f.strain_gamma_xy, f.strain_gamma_xz, f.strain_kappa_x, f.strain_kappa_y, f.strain_kappa_y);
-
-			return barForce;
-		}
-
-		public static IResult FromRFEM(this List<double> val, int lc, double memberLength, double location, int memberNumber )
-		{
-
-			//var f = memberInternalForces.row;
 
 			BarForce barForce = new BarForce(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
 
 			return barForce;
 		}
-
-		public static IResult FromRFEM(double x, double y, double z, double rx, double ry, double rz, int lc, double memberLength, double location, int memberNumber)
-		{
-			BarForce barForce = new BarForce(memberNumber, lc, -1, -1, Math.Round(location / memberLength, 4), 10, x, y, z, rx, ry, rz);
-			return barForce;
-		}
-
 
 	}
 }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -67,14 +67,13 @@ namespace BH.Adapter.RFEM6
 					break;
 
 				case BarResultType.BarStrain:
-					//result = new BarStrain(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
 					result = new BarStrain(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], 0,0,0,0,0,0);
 					BH.Engine.Base.Compute.RecordWarning($"For BarResultType {resultType}, no bending around Y or Z axis or combined axis bending has been determined.");
 					break;
 
 				default:
 					BH.Engine.Base.Compute.RecordError($"No conversion method for BarResultType {resultType} has been implemented.");
-					throw new ArgumentException($"Unsupported result type: {resultType}");
+					return null;
 			}
 
 

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -88,6 +88,22 @@ namespace BH.Adapter.RFEM6
 			return barForce;
 		}
 
+		public static IResult FromRFEM(this List<double> val, int lc, double memberLength, double location, int memberNumber )
+		{
+
+			//var f = memberInternalForces.row;
+
+			BarForce barForce = new BarForce(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
+
+			return barForce;
+		}
+
+		public static IResult FromRFEM(double x, double y, double z, double rx, double ry, double rz, int lc, double memberLength, double location, int memberNumber)
+		{
+			BarForce barForce = new BarForce(memberNumber, lc, -1, -1, Math.Round(location / memberLength, 4), 10, x, y, z, rx, ry, rz);
+			return barForce;
+		}
+
 
 	}
 }

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -50,7 +50,6 @@ namespace BH.Adapter.RFEM6
 		public static IResult FromRFEM(this List<double> val, int lc, double memberLength, double location, int memberNumber, BarResultType resultType)
 		{
 
-			BarForce barForce = new BarForce(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
 
 			IResult result;
 
@@ -79,7 +78,7 @@ namespace BH.Adapter.RFEM6
 			}
 
 
-			return barForce;
+			return result;
 		}
 
 	}

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Result/BarResults.cs
@@ -47,10 +47,37 @@ namespace BH.Adapter.RFEM6
 {
 	public static partial class Convert
 	{
-		public static IResult FromRFEM(this List<double> val, int lc, double memberLength, double location, int memberNumber)
+		public static IResult FromRFEM(this List<double> val, int lc, double memberLength, double location, int memberNumber, BarResultType resultType)
 		{
 
 			BarForce barForce = new BarForce(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
+
+			IResult result;
+
+			switch (resultType)
+			{
+				case BarResultType.BarForce:
+					result = new BarForce(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
+					break;
+				case BarResultType.BarDisplacement:
+					result = new BarDisplacement(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
+					break;
+
+				case BarResultType.BarDeformation:
+					result = new BarDeformation(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
+					break;
+
+				case BarResultType.BarStrain:
+					//result = new BarStrain(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], val[3], val[4], val[5]);
+					result = new BarStrain(memberNumber, lc, -1, -1, Math.Round((double)location / memberLength, 4), 10, val[0], val[1], val[2], 0,0,0,0,0,0);
+					BH.Engine.Base.Compute.RecordWarning($"For BarResultType {resultType}, no bending around Y or Z axis or combined axis bending has been determined.");
+					break;
+
+				default:
+					BH.Engine.Base.Compute.RecordError($"No conversion method for BarResultType {resultType} has been implemented.");
+					throw new ArgumentException($"Unsupported result type: {resultType}");
+			}
+
 
 			return barForce;
 		}

--- a/RFEM6_Adapter/RFEM6_Adapter.csproj
+++ b/RFEM6_Adapter/RFEM6_Adapter.csproj
@@ -17,7 +17,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dlubal.RFEMWebServiceLibrary" Version="6.7.6" />
+		<PackageReference Include="Dlubal.RFEMWebServiceLibrary" Version="6.8.2" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Private.ServiceModel" Version="4.10.0" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
The current version of the RFEM6_Toolkit does not support reading BarResults. This PR adds this feature to the Toolkit. Currently, only the pulling of BarForces, BarDeformation, BarDisplacements, and BarStrains will be supported. An additional constraint concerns the divisions. Based on current knowledge, RFEM6 provides limited abilities to customize the number of divisions, so this PR will work with RFEM6's standard settings.

Closes #97 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[GH-File
](https://burohappold.sharepoint.com/:u:/s/BHoM/EYxtwieYYCdFnsLDy4jvgh4B1qbcDe_1vUCzC8HsUuXM9w?e=HYWvvt)
[RFEM6-File](https://burohappold.sharepoint.com/:u:/s/BHoM/ETMNNCLFJNlHhCUuLW1ZIGoBPI-fBcKDn2kuC3E08-IyNw?e=hW36hi)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Adding an read method for BarResults
- Adding a correspoinding Convert (FromRFEM) method

### Additional comments
<!-- As required -->

- The pull component includes FX, FY, FZ, MX, MY, MZ values. When pulling, we handle forces, deformations, displacements, and strains. The corresponding directions align with these components.
- When pulling extremes, each bar follows the same pattern. You receive one BarResult per bar, containing a single extreme value. The pattern follows: MaxX, MinX, MaxY, MinY... through MinMZ. 

- For the testing: When Running the GH Script you should have finalized the calcs in RFEM6 First. 


