### PR TITLE
Read BarResulst For LoadCombinations

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/LoadCombination.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/LoadCombination.cs
@@ -27,60 +27,47 @@ using BH.Engine.Structure;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
-using BH.oM.Analytical.Elements;
-using BH.oM.Base;
-using BH.oM.Structure.Requests;
 using BH.oM.Structure.Loads;
+using Dlubal.WS.Rfem6.Model;
+using BH.Engine.Geometry;
+using System.Security.Permissions;
+using BH.oM.Base;
 
 namespace RFEM_Toolkit_Test.Elements
 {
 
 
-	public class BarResultTestClass
+    public class LoadCombination_Test
 
-	{
+    {
 
-		RFEM6Adapter adapter;
+        RFEM6Adapter adapter;
 
-		//[TearDown]
-		//public void TearDown()
-		//{
-		//	adapter.Wipeout();
-		//}
 
-		[OneTimeSetUp]
-		public void InitializeRFEM6Adapter()
-		{
-			adapter = new RFEM6Adapter(true);
+        [SetUp]
+        public void EveryTimeSetUp()
+        {
+            //adapter = new RFEM6Adapter(true);
+        }
 
-		}
+        [OneTimeSetUp]
+        public void SetUpScenario()
+        {
+            adapter = new RFEM6Adapter(true);
 
-		[Test]
-		public void ReadResult()
-		{
-			List<LoadCombination?> loadCombList = adapter.Pull(new FilterRequest() { Type = typeof(LoadCombination) }).Select(l=> l as LoadCombination).ToList();
+        }
 
-			Loadcase loadcase1 = new Loadcase() { Name = "LC1", Nature = LoadNature.Dead, Number = 1 };
-			LoadCombination loadCombination = new LoadCombination { Name = "LoadCombination1", Number = 1 };
+        [Test]
+        public void PullCoadCombination()
+        {
 
-			BarResultRequest request = new BarResultRequest();
-
-			request.ResultType = BarResultType.BarForce;
-			request.DivisionType = DivisionType.EvenlyDistributed;
-			request.Divisions = 3;
-			request.Cases = new List<Object> { loadCombList.First() };
-			request.Modes = new List<string>();
-			request.ObjectIds = new List<object> {1};
-			//request.ObjectIds = new List<object> {1,2,3,4};
-
-			var obj = adapter.Pull(request);
-
-			obj.First();
+            
+           adapter.Pull(new FilterRequest() { Type = typeof(LoadCombination) });
 
 		}
 
 
 
-	}
+    }
 }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/LoadCombination.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/LoadCombination.cs
@@ -57,12 +57,25 @@ namespace RFEM_Toolkit_Test.Elements
 
         }
 
+  //      [Test]
+  //      public void PullLoadCombination()
+  //      {
+
+           
+  //         var res= adapter.Pull(new FilterRequest() { Type = typeof(LoadCombination) });
+
+  //         var a =  res.ToArray().Count();
+
+		//}   
+        
         [Test]
-        public void PullCoadCombination()
+        public void PushLoadCombination()
         {
 
-            
-           adapter.Pull(new FilterRequest() { Type = typeof(LoadCombination) });
+			LoadCombination lc = new LoadCombination();
+
+			var res= adapter.Push(new List<Object>() { lc });
+
 
 		}
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -30,6 +30,7 @@ using BH.oM.Structure.Elements;
 using BH.oM.Analytical.Elements;
 using BH.oM.Base;
 using BH.oM.Structure.Requests;
+using BH.oM.Structure.Loads;
 
 namespace RFEM_Toolkit_Test.Elements
 {
@@ -58,12 +59,15 @@ namespace RFEM_Toolkit_Test.Elements
 		public void ReadResult()
 		{
 
+			Loadcase loadcase1 = new Loadcase() { Name = "LC1", Nature = LoadNature.Dead, Number = 1 };
+			LoadCombination loadCombination = new LoadCombination { Name = "LoadCombination1", Number = 1 };
+
 			BarResultRequest request = new BarResultRequest();
 
 			request.ResultType = BarResultType.BarForce;
 			request.DivisionType = DivisionType.EvenlyDistributed;
 			request.Divisions = 3;
-			request.Cases = new List<Object> { 1 };
+			request.Cases = new List<Object> { loadCombination };
 			request.Modes = new List<string>();
 			request.ObjectIds = new List<object> {1};
 			//request.ObjectIds = new List<object> {1,2,3,4};

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/LoadCombination.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/LoadCombination.cs
@@ -1,0 +1,97 @@
+///*
+// * This file is part of the Buildings and Habitats object Model (BHoM)
+// * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+// *
+// * Each contributor holds copyright over their respective contributions.
+// * The project versioning (Git) records all such contribution source information.
+// *                                           
+// *                                                                              
+// * The BHoM is free software: you can redistribute it and/or modify         
+// * it under the terms of the GNU Lesser General Public License as published by  
+// * the Free Software Foundation, either version 3.0 of the License, or          
+// * (at your option) any later version.                                          
+// *                                                                              
+// * The BHoM is distributed in the hope that it will be useful,              
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+// * GNU Lesser General Public License for more details.                          
+// *                                                                            
+// * You should have received a copy of the GNU Lesser General Public License     
+// * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+// */
+
+//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Text;
+//using System.Numerics;
+
+//using BH.oM.Adapter;
+//using BH.oM.Structure.Elements;
+//using BH.oM.Structure.Constraints;
+
+//using rfModel = Dlubal.WS.Rfem6.Model;
+//using BH.Engine.Structure;
+//using BH.oM.Structure.Loads;
+//using BH.oM.Adapter.Commands;
+//using Dlubal.WS.Rfem6.Model;
+
+//namespace BH.Adapter.RFEM6
+//{
+//    public partial class RFEM6Adapter
+//    {
+//        private bool CreateCollection(IEnumerable<LoadCombination> bhLoadCombinations)
+//        {
+
+//            // Taking Care of Analysis Settings
+
+//            //Check if Analysis Setting does exist already
+//            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_DESIGN_SITUATION);
+//            List<rfModel.design_situation> foundDesingSituations = numbers.ToList().Select(n => m_Model.get_design_situation(n.no)).ToList();
+
+//			Dictionary<int, Loadcase> LoadCaseDict = this.GetCachedOrReadAsDictionary<int, Loadcase>();
+
+//			rfModel.design_situation analysis;
+
+//            if (foundDesingSituations.Count == 0)
+//            {
+//                int no=m_Model.get_first_free_number(rfModel.object_types.E_OBJECT_TYPE_DESIGN_SITUATION, 0);
+
+
+//				analysis = new design_situation()
+//                {
+//                    no = no,
+//					//name = $"DS {no}",
+//					//user_defined_name_enabled = true,
+//					//user_defined_name_enabledSpecified = true,
+//					design_situation_type = "DESIGN_SITUATION_TYPE_EQU_PERMANENT_AND_TRANSIENT",
+//					is_generated = false,
+//					is_generatedSpecified = true,
+//					consider_inclusive_exclusive_load_cases = false,
+//					consider_inclusive_exclusive_load_casesSpecified = false,
+//				};
+
+//                m_Model.set_design_situation(analysis);
+//			}
+//            else
+//            {
+
+//                analysis = foundDesingSituations.Find(s => s.design_situation_type == "DESIGN_SITUATION_TYPE_EQU_PERMANENT_AND_TRANSIENT");
+
+//            }
+
+//			foreach (LoadCombination loadCombination in bhLoadCombinations)
+//			{
+//				//Convert Load Case to RFEM6
+//				rfModel.load_combination rfLoadCombination = loadCombination.ToRFEM6(analysis.no);
+//				//Set Load Case
+//				m_Model.set_load_combination(rfLoadCombination);
+//			}
+
+//			return true;
+//        }
+
+//    }
+//}
+
+

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/LoadCombination.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/LoadCombination.cs
@@ -19,68 +19,49 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-using BH.Adapter.RFEM6;
-using BH.Engine.Base;
-using BH.oM.Data.Requests;
-using BH.oM.Structure.MaterialFragments;
-using BH.Engine.Structure;
-using BH.oM.Structure.SectionProperties;
-using BH.oM.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using BH.oM.Adapter;
 using BH.oM.Structure.Elements;
-using BH.oM.Analytical.Elements;
-using BH.oM.Base;
-using BH.oM.Structure.Requests;
+using BH.oM.Structure.Constraints;
+
+using rfModel = Dlubal.WS.Rfem6.Model;
+using BH.oM.Adapters.RFEM6;
 using BH.oM.Structure.Loads;
 
-namespace RFEM_Toolkit_Test.Elements
+namespace BH.Adapter.RFEM6
 {
+    public partial class RFEM6Adapter
+    {
 
+        private List<LoadCombination> ReadLoadCombination(List<string> ids = null)
+        {
+            // Get all Loadcases from RFEM6
+            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LOAD_COMBINATION);
+			IEnumerable<rfModel.load_combination> foundLoadCombinations = numbers.ToList().Select(n => m_Model.get_load_combination(n.no));
+			Dictionary<int, Loadcase> LoadCombinationsDict = this.GetCachedOrReadAsDictionary<int, Loadcase>();
 
-	public class BarResultTestClass
+			List<LoadCombination> loadCases = new List<LoadCombination>();
+           
+            // Convert the RFEM Loadcases to BHoM Loadcases
+            foreach (rfModel.load_combination loadCombination in foundLoadCombinations)
+            {
+                //var b= loadCombination.individual_factors_of_selected_objects_table;
+                loadCases.Add(loadCombination.FromRFEM(LoadCombinationsDict));
+                
 
-	{
+            }
 
-		RFEM6Adapter adapter;
+            // Sort the Loadcases by Number
+            loadCases.Sort((x, y) => x.Number.CompareTo(y.Number));
 
-		//[TearDown]
-		//public void TearDown()
-		//{
-		//	adapter.Wipeout();
-		//}
+            return loadCases;
+        }
 
-		[OneTimeSetUp]
-		public void InitializeRFEM6Adapter()
-		{
-			adapter = new RFEM6Adapter(true);
-
-		}
-
-		[Test]
-		public void ReadResult()
-		{
-			List<LoadCombination?> loadCombList = adapter.Pull(new FilterRequest() { Type = typeof(LoadCombination) }).Select(l=> l as LoadCombination).ToList();
-
-			Loadcase loadcase1 = new Loadcase() { Name = "LC1", Nature = LoadNature.Dead, Number = 1 };
-			LoadCombination loadCombination = new LoadCombination { Name = "LoadCombination1", Number = 1 };
-
-			BarResultRequest request = new BarResultRequest();
-
-			request.ResultType = BarResultType.BarForce;
-			request.DivisionType = DivisionType.EvenlyDistributed;
-			request.Divisions = 3;
-			request.Cases = new List<Object> { loadCombList.First() };
-			request.Modes = new List<string>();
-			request.ObjectIds = new List<object> {1};
-			//request.ObjectIds = new List<object> {1,2,3,4};
-
-			var obj = adapter.Pull(request);
-
-			obj.First();
-
-		}
-
-
-
-	}
+    }
 }
+
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -54,41 +54,64 @@ namespace BH.Adapter.RFEM6
 			//Warnings 
 			BH.Engine.Base.Compute.RecordWarning($"Divisions are set to {request.Divisions}. Division functionality has not been implemented yet in RFEM6_Toolkit. Currently, the number of divisions depends solely on what RFEM6 provides and can vary significantly based on the load type on the corresponding Bar/Member and the DivisionType.");
 
+			if (request.Cases.Where(c=> c is string).ToList().Count>0) { BH.Engine.Base.Compute.RecordWarning("At least one instance of the Case input is neither of type LoadCase nor LoadCombination. The set CaseIds will be assumed to be LoadCase IDs for now."); };
+
 			//RFEM Specific Stuff
 			m_Model.use_detailed_member_results(true);
 
 			// Loading of Member And LoadCase Ids
 			List<int> memberIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
-			List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
+			//List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
 
 			// Definition of Object Locations for Members
-			object_location[] objectLocatioons = memberIds.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_MEMBER, no = n, parent_no = 0 }).ToArray();
+			object_location[] objectLocations = memberIds.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_MEMBER, no = n, parent_no = 0 }).ToArray();
 
 			//ResultList
 			List<IResult> resultList = new List<IResult>();
 
 
-			foreach (int c in loadCaseIds)
+			foreach (var c in request.Cases)
 			{
+				int cId = 0;
+
+				if (c is Loadcase)
+				{
+					cId = (c as Loadcase).Number;
+
+				}
+				else if (c is LoadCombination)
+				{
+
+					cId = (c as LoadCombination).Number;
+
+				}
+				else
+				{
+
+					cId = Int32.Parse(c.ToString());
+				}
+
+
 
 				//Loading resulst from RFEM
 				INotifyPropertyChanged[] barResults = new INotifyPropertyChanged[1];
 
+				var loadingType = c is LoadCombination ? case_object_types.E_OBJECT_TYPE_LOAD_COMBINATION : case_object_types.E_OBJECT_TYPE_LOAD_CASE;
 
 				switch (request.ResultType)
 				{
 
 					case BarResultType.BarForce:
-						barResults = m_Model.get_results_for_members_internal_forces(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
+						barResults = m_Model.get_results_for_members_internal_forces(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
 						break;
 					case BarResultType.BarDisplacement:
-						barResults = m_Model.get_results_for_members_global_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons);
+						barResults = m_Model.get_results_for_members_global_deformations(loadingType, cId, objectLocations);
 						break;
 					case BarResultType.BarDeformation:
-						barResults = m_Model.get_results_for_members_local_deformations(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
+						barResults = m_Model.get_results_for_members_local_deformations(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
 						break;
 					case BarResultType.BarStrain:
-						barResults = m_Model.get_results_for_members_strains(case_object_types.E_OBJECT_TYPE_LOAD_CASE, c, objectLocatioons, axes_type.MEMBER_AXES);
+						barResults = m_Model.get_results_for_members_strains(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
 						break;
 					default:
 						BH.Engine.Base.Compute.RecordError($"The pull result types of type {request.ResultType} has not been developed Yet");
@@ -128,7 +151,7 @@ namespace BH.Adapter.RFEM6
 
 					}
 
-					int corrective = (request.ResultType == BarResultType.BarDisplacement || request.ResultType == BarResultType.BarDeformation) ? 0 : 2; 
+					int corrective = (request.ResultType == BarResultType.BarDisplacement || request.ResultType == BarResultType.BarDeformation) ? 0 : 2;
 					// important do to enable processing of Deformations due to the |u|
 					if (memberSegmentValues?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
 					{
@@ -153,7 +176,7 @@ namespace BH.Adapter.RFEM6
 							e.PropertyValue($"row.{props[p.Item1].Name}").ToString()
 						));
 
-						var result = val.Values.ToList().FromRFEM(c, memberLength, location, memberNumber,request.ResultType);
+						var result = val.Values.ToList().FromRFEM(cId, memberLength, location, memberNumber, request.ResultType);
 						resultList.Add(result);
 					}
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -138,7 +138,6 @@ namespace BH.Adapter.RFEM6
 					if (request.DivisionType == DivisionType.ExtremeValues)
 					{
 
-
 						memberSegmentValues = member.SkipWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
 						memberSegmentValues = memberSegmentValues.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Total")).ToList();
 
@@ -161,7 +160,6 @@ namespace BH.Adapter.RFEM6
 					//Conversion for every segment of member
 					foreach (var e in memberSegmentValues)
 					{
-
 
 						var location = Double.Parse(e.PropertyValue("row.location").ToString());
 						var memberNumber = Int32.Parse(e.PropertyValue("row.member_no").ToString());

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -61,7 +61,6 @@ namespace BH.Adapter.RFEM6
 
 			// Loading of Member And LoadCase Ids
 			List<int> memberIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
-			//List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
 
 			// Definition of Object Locations for Members
 			object_location[] objectLocations = memberIds.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_MEMBER, no = n, parent_no = 0 }).ToArray();

--- a/RFEM6_Adapter/CRUD/Read/_IRead.cs
+++ b/RFEM6_Adapter/CRUD/Read/_IRead.cs
@@ -81,7 +81,9 @@ namespace BH.Adapter.RFEM6
                     return ReadOpening(ids as dynamic);
                 else if (type == typeof(Loadcase))
                     return ReadLoadCase(ids as dynamic);
-                else if (type == typeof(BarUniformlyDistributedLoad))
+				else if (type == typeof(LoadCombination))
+					return ReadLoadCombination(ids as dynamic);
+				else if (type == typeof(BarUniformlyDistributedLoad))
                     return ReadBarLoad(ids as dynamic);
                 else if (type == typeof(PointLoad))
                     return ReadPointLoad(ids as dynamic);

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/LoadCombination.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/LoadCombination.cs
@@ -1,0 +1,96 @@
+///*
+// * This file is part of the Buildings and Habitats object Model (BHoM)
+// * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+// *
+// * Each contributor holds copyright over their respective contributions.
+// * The project versioning (Git) records all such contribution source information.
+// *                                           
+// *                                                                              
+// * The BHoM is free software: you can redistribute it and/or modify         
+// * it under the terms of the GNU Lesser General Public License as published by  
+// * the Free Software Foundation, either version 3.0 of the License, or          
+// * (at your option) any later version.                                          
+// *                                                                              
+// * The BHoM is distributed in the hope that it will be useful,              
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+// * GNU Lesser General Public License for more details.                          
+// *                                                                            
+// * You should have received a copy of the GNU Lesser General Public License     
+// * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+// */
+//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Text;
+
+//using BH.oM.Adapter;
+//using BH.oM.Structure.Elements;
+//using BH.Engine.Adapter;
+//using BH.oM.Adapters.RFEM6;
+
+//using rfModel = Dlubal.WS.Rfem6.Model;
+//using BH.Engine.Base;
+//using BH.oM.Structure.Loads;
+//using BH.oM.Adapter.Commands;
+//using Dlubal.WS.Rfem6.Model;
+
+//namespace BH.Adapter.RFEM6
+//{
+//	public static partial class Convert
+//	{
+
+//		public static rfModel.load_combination ToRFEM6(this LoadCombination bhLoadCombination, int analysisNo)
+//		{
+
+//			List<load_combination_items_row> loadCombinationItems = new List<load_combination_items_row>();
+
+//			int counter = 1;
+//			foreach (var loadCase in bhLoadCombination.LoadCases)
+//			{
+
+//				load_combination_items_row loadCombinationRow = new load_combination_items_row()
+//				{
+//					no = counter,
+//					row = new load_combination_items()
+//					{
+//						load_case = loadCase.Item2.Number,
+//						load_caseSpecified = true,
+//						factor = loadCase.Item1,
+//						factorSpecified = true,
+//					}
+
+//				};
+
+//				loadCombinationItems.Add(loadCombinationRow);
+
+//				counter++;
+
+//			}
+//			//TODO: Check create Load Combination
+
+//			load_combination load_Combination = new load_combination()
+//			{
+//				no = 1,
+//				name = "ScriptedCombination",
+//				user_defined_name_enabled = true,
+//				user_defined_name_enabledSpecified = true,
+//				to_solve = true,
+//				to_solveSpecified = true,
+//				analysis_type = load_combination_analysis_type.ANALYSIS_TYPE_STATIC,
+//				analysis_typeSpecified = true,
+//				items = loadCombinationItems.ToArray(),
+//				design_situation = 1,
+//				design_situationSpecified = true,
+//			};
+
+//			return load_Combination;
+
+//		}
+
+//	}
+
+//}
+
+
+

--- a/RFEM6_Adapter/RFEM6AdapterSettings.cs
+++ b/RFEM6_Adapter/RFEM6AdapterSettings.cs
@@ -75,8 +75,9 @@ namespace BH.Adapter.RFEM6
                 {typeof(PointLoad), new List<Type> { typeof(Node), typeof(Loadcase) } },
                 {typeof(AreaUniformlyDistributedLoad), new List<Type> { typeof(Panel), typeof(Loadcase) } },
                 {typeof(GeometricalLineLoad), new List<Type> { typeof(Panel), typeof(Loadcase)} },
+				{typeof(LoadCombination), new List<Type> { typeof(Loadcase)} },
 
-            };
+			};
 
         }
 
@@ -110,7 +111,6 @@ namespace BH.Adapter.RFEM6
                 {typeof(Edge), new EdgeComparer()},
                 {typeof(RFEMLineSupport), new RFEMLineSupportComparer() },
                 {typeof(RFEMLine), new RFEMLineComparer(3) },
-                //{typeof(Panel), new RFEMPanelComparer() },
 				{typeof(Panel), new PanelComparer() },
 				{typeof(Loadcase), new LoadCaseComparer() },
             };


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

The current version of the RFEM6_Toolkit does not support reading BarResults for LoadCombination. This PR adds this feature to the Toolkit. Currently, only the pulling of BarForces, BarDeformation, BarDisplacements, and BarStrains will be supported. An additional constraint concerns the divisions. Based on current knowledge, RFEM6 provides limited abilities to customize the number of divisions, so this PR will work with RFEM6's standard setting

Closes #108 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
