### PR TITLE
Fix compilation via dotnet build

### DIFF
--- a/RFEM6_Engine/RFEM6_Engine.csproj
+++ b/RFEM6_Engine/RFEM6_Engine.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+		<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
 		<OutputPath>..\Build\</OutputPath>
 	</PropertyGroup>
 

--- a/RFEM6_oM/RFEM6_oM.csproj
+++ b/RFEM6_oM/RFEM6_oM.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
+		<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
 		<OutputPath>..\Build\</OutputPath>
 	</PropertyGroup>
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #110 

Two projects files had `GenerateSerializationAssemblies` turned on so both were fixed.


### Test files
No need for test file, just run `dotnet build .\BHoM.sln` in a command window to make sure the code now compiles successfully. 