### PR TITLE
Define which model should be pushed or pulled

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Comparer/Section.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Comparer/Section.cs
@@ -82,7 +82,7 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
 		public void InitializeRFEM6Adapter()
 		{
 
-			adapter = new RFEM6Adapter(true);
+			adapter = new RFEM6Adapter(active:true);
 			comparer = new RFEMSectionComparer();
 
 		}

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Edge.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Edge.cs
@@ -44,7 +44,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
         }
 
         [TearDown]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Bar/Bar.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Bar/Bar.cs
@@ -74,7 +74,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
 
             //Set Up Materials

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Material/Material.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Material/Material.cs
@@ -53,7 +53,7 @@ namespace RFEM_Toolkit_Test.Elements
             /***************************************************/
             /**** Arrange                                   ****/
             /***************************************************/
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
             comparer = new NameOrDescriptionComparer();
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Panel/Panel.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Panel/Panel.cs
@@ -76,7 +76,7 @@ namespace RFEM_Toolkit_Test.Elements
 
 
 
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
             comparer = new RFEMPanelComparer();
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/Section.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/Section.cs
@@ -55,7 +55,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
             comparer = new RFEMSectionComparer();
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/SectionFuzzyMatching.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/SectionFuzzyMatching.cs
@@ -57,7 +57,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
             comparer = new RFEMSectionComparer();
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/Section_Refactored.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Section/Section_Refactored.cs
@@ -55,7 +55,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
             comparer = new RFEMSectionComparer();
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/BarLoad.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/BarLoad.cs
@@ -125,14 +125,14 @@ namespace RFEM_Toolkit_Test.Elements
         [SetUp]
         public void EveryTimeSetUp()
         {
-            //adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(filePath: @"C:\Users\amartensen\Downloads\test3.rf6", active: true);
             adapter.Push(new List<Bar>() { barSteelSection0, barSteelSection1, barSteelSection2 });
         }
 
         [OneTimeSetUp]
         public void SetUpScenario()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
             //Set Up Sections
             steelSection = BH.Engine.Library.Query.Match("EU_SteelSections", "IPE 300", true, true) as ISectionProperty;

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/GeometricalLineLoadFree.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/GeometricalLineLoadFree.cs
@@ -90,7 +90,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeOpenings()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
             comparer = new RFEMPanelComparer();
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/GeometricalLineLoadNonFree.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/GeometricalLineLoadNonFree.cs
@@ -88,7 +88,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeOpenings()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
             comparer = new RFEMPanelComparer();
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/LoadCombination.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/LoadCombination.cs
@@ -47,13 +47,13 @@ namespace RFEM_Toolkit_Test.Elements
         [SetUp]
         public void EveryTimeSetUp()
         {
-            //adapter = new RFEM6Adapter(true);
+            //adapter = new RFEM6Adapter(active:true);
         }
 
         [OneTimeSetUp]
         public void SetUpScenario()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/Loadcase.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/Loadcase.cs
@@ -68,7 +68,7 @@ namespace RFEM_Toolkit_Test.Elements
         [SetUp]
         public void EveryTimeSetUp()
         {
-            //adapter = new RFEM6Adapter(true);
+            //adapter = new RFEM6Adapter(active:true);
             loadcase1 = new Loadcase() { Name = "LC1", Nature = LoadNature.Dead, Number = 1 };
             loadcase2 = new Loadcase() { Name = "LC2", Nature = LoadNature.Accidental, Number = 2 };
             loadcase3 = new Loadcase() { Name = "LC3", Nature = LoadNature.Live, Number = 3 };
@@ -91,7 +91,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void SetUpScenario()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
         }
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/PointLoad.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/PointLoad.cs
@@ -76,7 +76,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void Initialize()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
             node0 = new Node() { Position = new Point() { X = 0, Y = 0, Z = 0 } };
             node1 = new Node() { Position = new Point() { X = 10, Y = 0, Z = 0 } };
             node2 = new Node() { Position = new Point() { X = 20, Y = 0, Z = 0 } };

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/UniformlyDistributedAreaLoad.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/UniformlyDistributedAreaLoad.cs
@@ -74,7 +74,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeOpenings()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
 
             comparer = new RFEMPanelComparer();
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Material.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Material.cs
@@ -41,7 +41,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
         }
 
         [TearDown]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Node.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Node.cs
@@ -42,7 +42,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
         }
 
         [TearDown]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -51,7 +51,7 @@ namespace RFEM_Toolkit_Test.Elements
 		[OneTimeSetUp]
 		public void InitializeRFEM6Adapter()
 		{
-			adapter = new RFEM6Adapter(true);
+			adapter = new RFEM6Adapter(active:true);
 
 		}
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/NodalResult.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/NodalResult.cs
@@ -77,7 +77,7 @@ namespace RFEM_Toolkit_Test.Elements
 		[OneTimeSetUp]
 		public void InitializeRFEM6Adapter()
 		{
-			adapter = new RFEM6Adapter(true);
+			adapter = new RFEM6Adapter(active:true);
 
 
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Section.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Section.cs
@@ -37,7 +37,7 @@ namespace RFEM_Toolkit_Test.Elements
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
         }
 
         [TearDown]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/Edge_Test.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/Edge_Test.cs
@@ -41,7 +41,7 @@ using System.Threading.Tasks;
 
 namespace RFEM_Toolkit_Test.Comparer_Tests
 {
-    internal class ComparerTests
+    internal class Edge_Test
     {
 
         EdgeComparer edgeComparer;
@@ -119,6 +119,7 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         IProfile concreteRectangleProfile;
 
         [SetUp]
+        [Description("Set up scenario.")]
         public void Edge_Test_Setup()
         {
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/Edge_Test.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/Edge_Test.cs
@@ -119,7 +119,7 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         IProfile concreteRectangleProfile;
 
         [SetUp]
-        public void Setup()
+        public void Edge_Test_Setup()
         {
 
             node0 = new Node() { Position = new Point() { X = 0, Y = 0, Z = 0 } };
@@ -215,7 +215,7 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         [OneTimeSetUp]
 
         [Description("Method Initializes all used components ones.")]
-        public void InitializeRFEM6Adapter()
+        public void Edge_Test_InitializeRFEM6Adapter()
         {
             edgeComparer = new EdgeComparer();
             hingeComparer = new RFEMHingeComparer();
@@ -231,7 +231,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         }
 
         [Test]
-        public void EdgeComparer_Test()
+        [Description("Test.")]
+        public void Edge_Test_EdgeComparer_Test()
         {
             //Test equal Elements for equality
             Assert.IsTrue(edgeComparer.Equals(edge0, edge0));
@@ -243,7 +244,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         }
 
         [Test]
-        public void HingeComparer_Test()
+        [Description("Test.")]
+        public void Edge_Test_HingeComparer_Test()
         {
             //Test equal Elements for equality
             Assert.IsTrue(hingeComparer.Equals(hinge0, hinge0));
@@ -256,7 +258,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         }
 
         [Test]
-        public void LineComparer_Test()
+        [Description("Test.")]
+        public void Edge_Test_LineComparer_Test()
         {
             ////Test equal Elements for equality////
 
@@ -291,7 +294,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         }
 
         [Test]
-        public void LineSupportComparer_Test()
+        [Description("Test.")]
+        public void Edge_Test_LineSupportComparer_Test()
         {
 
 
@@ -307,7 +311,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         }
 
         [Test]
-        public void NodalSupportComparer_Test()
+        [Description("Test.")]
+        public void Edge_Test_NodalSupportComparer_Test()
         {
 
 
@@ -322,7 +327,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         }
 
         [Test]
-        public void SectionComparer_Test()
+        [Description("Test.")]
+        public void Edge_Test_SectionComparer_Test()
         {
 
             //Steel
@@ -347,7 +353,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
 
 
         [Test]
-        public void PanelComparer_Test()
+        [Description("Test.")]
+        public void Edge_Test_PanelComparer_Test()
         {
 
             //Define two equal objects e0 and e1
@@ -361,7 +368,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         }
 
         [Test]
-        public void SurfaceProperty_Test()
+        [Description("Test.")]
+        public void Edge_Test_SurfaceProperty_Test()
         {
 
             //Define two equal objects e0 and e1

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/Edge_Test.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/Edge_Test.cs
@@ -213,6 +213,8 @@ namespace RFEM_Toolkit_Test.Comparer_Tests
         }
 
         [OneTimeSetUp]
+
+        [Description("Method Initializes all used components ones.")]
         public void InitializeRFEM6Adapter()
         {
             edgeComparer = new EdgeComparer();

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
@@ -58,7 +58,7 @@ namespace RFEM_Toolkit_Test.Loading
 
 
         [OneTimeSetUp]
-        public void InitializeRFEM6Adapter()
+        public void PushPullLoadComparer_InitializeRFEM6Adapter()
         {
             adapter = new RFEM6Adapter(active:true);
         }

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
@@ -60,7 +60,7 @@ namespace RFEM_Toolkit_Test.Loading
         [OneTimeSetUp]
         public void LoadComparerTest_InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(active:true);
+            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active: true);
         }
 
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
@@ -70,7 +70,7 @@ namespace RFEM_Toolkit_Test.Loading
         [Test]
 
         [Description("Test For Comparing Pushed vs Pulled Loads.")]
-        public void CompareLoads()
+        public void LoadComparerTest_CompareLoads()
         {
             n1 = new Node() { Position = new Point() { X = 0, Y = 10, Z = 0 }, Support = BH.Engine.Structure.Create.FixConstraint6DOF() };
             n2 = new Node() { Position = new Point() { X = 10, Y = 10, Z = 0 }, Support = BH.Engine.Structure.Create.FixConstraint6DOF() };

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
@@ -58,6 +58,8 @@ namespace RFEM_Toolkit_Test.Loading
 
 
         [OneTimeSetUp]
+
+        [Description("Method Initializes all used components ones")]
         public void LoadComparerTest_InitializeRFEM6Adapter()
         {
             adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active: true);

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
@@ -40,7 +40,7 @@ namespace RFEM_Toolkit_Test.Loading
 {
 
 
-    public class PushPullLoadComparer
+    public class LoadComparerTest
 
     {
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
@@ -59,7 +59,7 @@ namespace RFEM_Toolkit_Test.Loading
 
         [OneTimeSetUp]
 
-        [Description("Method Initializes all used components ones")]
+        [Description("Method Initializes all used components ones.")]
         public void LoadComparerTest_InitializeRFEM6Adapter()
         {
             adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active: true);
@@ -68,6 +68,8 @@ namespace RFEM_Toolkit_Test.Loading
 
 
         [Test]
+
+        [Description("Test For Comparing Pushed vs Pulled Loads.")]
         public void CompareLoads()
         {
             n1 = new Node() { Position = new Point() { X = 0, Y = 10, Z = 0 }, Support = BH.Engine.Structure.Create.FixConstraint6DOF() };

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
@@ -60,7 +60,7 @@ namespace RFEM_Toolkit_Test.Loading
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new RFEM6Adapter(true);
+            adapter = new RFEM6Adapter(active:true);
         }
 
 

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Comparer_Tests/LoadComparerTest.cs
@@ -58,7 +58,7 @@ namespace RFEM_Toolkit_Test.Loading
 
 
         [OneTimeSetUp]
-        public void PushPullLoadComparer_InitializeRFEM6Adapter()
+        public void LoadComparerTest_InitializeRFEM6Adapter()
         {
             adapter = new RFEM6Adapter(active:true);
         }

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/BarRelease_Test.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/BarRelease_Test.cs
@@ -52,7 +52,7 @@ namespace RFEM_Toolkit_Test
         [OneTimeSetUp]
         public void InitializeRFEM6Adapter()
         {
-            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(true);
+            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active:true);
         }
 
         [Test]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/Bar_Test.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/Bar_Test.cs
@@ -49,7 +49,7 @@
 //        [OneTimeSetUp]
 //        public void InitializeRFEM6Adapter()
 //        {
-//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(true);
+//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active:true);
 //        }
 
 //        [Test]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/Material_Test.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/Material_Test.cs
@@ -51,7 +51,7 @@
 //        [OneTimeSetUp]
 //        public void InitializeRFEM6Adapter()
 //        {
-//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(true);
+//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active:true);
 //        }
 
 //        [Test]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/Panel_Test.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/Panel_Test.cs
@@ -49,7 +49,7 @@
 //        [OneTimeSetUp]
 //        public void InitializeRFEM6Adapter()
 //        {
-//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(true);
+//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active:true);
 //        }
 
 //        [Test]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/RFEMLineSupport.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/RFEMLineSupport.cs
@@ -46,7 +46,7 @@
 //        [OneTimeSetUp]
 //        public void InitializeRFEM6Adapter()
 //        {
-//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(true);
+//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active:true);
 //        }
 
 //        [Test]

--- a/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/Section_Test.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/Unsorted/Section_Test.cs
@@ -54,7 +54,7 @@
 //        [OneTimeSetUp]
 //        public void InitializeRFEM6Adapter()
 //        {
-//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(true);
+//            adapter = new BH.Adapter.RFEM6.RFEM6Adapter(active:true);
 //        }
 
 //        [Test]

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -63,7 +63,6 @@ namespace BH.Adapter.RFEM6
         {
 
             // The Adapter constructor can be used to configure the Adapter behaviour.
-            // For example:
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.FullPush; // Adapter `Push` Action simply calls "Create" method.
             //m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateOnly;
             m_AdapterSettings.OnlyUpdateChangedObjects = false; // Setting this to true causes a Stackoverflow in some cases from the HashComparer called from the base FullCRUD.
@@ -85,7 +84,7 @@ namespace BH.Adapter.RFEM6
         /**** Private  Fields                           ****/
         /***************************************************/
 
-        public string m_filepath = "";
+        private string m_filepath = "";
 
         public Dictionary<Loadcase, Dictionary<String, int>> m_LoadcaseLoadIdDict = new Dictionary<Loadcase, Dictionary<String, int>>(new LoadCaseComparer());
         public Dictionary<Panel, int> m_PanelIDdict = new Dictionary<Panel, int>(new RFEMPanelComparer());
@@ -118,11 +117,7 @@ namespace BH.Adapter.RFEM6
 
                 }
 
-                 //modelUrl = m_Application.get_active_model();
-                // connects to RFEM6/RSTAB9 model
                 m_Model = new RfemModelClient(Binding, new EndpointAddress(modelUrl));
-                //m_Model.get_model_settings_and_options().global_axes_orientation=model_settings_and_options_global_axes_orientation_type.E_GLOBAL_AXES_ORIENTATION_ZUP;
-                //m_Model.get_model_settings_and_options().global_axes_orientationSpecified = true;
 
             }
             else

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -56,7 +56,7 @@ namespace BH.Adapter.RFEM6
         /***************************************************/
         /**** Constructors                              ****/
         /***************************************************/
-        [PreviousVersion("8.2", "BH.Adapter.RFEM6Adapter.RFEM6Adapter(bool)")]
+        [PreviousVersion("8.3", "BH.Adapter.RFEM6Adapter.RFEM6Adapter(bool)")]
         [Description("Adapter for RFEM6.")]
         [Output("The created RFEM6 adapter.")]
         public RFEM6Adapter(string filePath = "", bool active = false)

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -46,6 +46,7 @@ using BH.oM.Adapters.RFEM6;
 using BH.Engine.Structure;
 using BH.Engine.Geometry;
 using BH.oM.Adapter;
+using System.Diagnostics;
 
 
 namespace BH.Adapter.RFEM6
@@ -58,7 +59,7 @@ namespace BH.Adapter.RFEM6
 
         [Description("Adapter for RFEM6.")]
         [Output("The created RFEM6 adapter.")]
-        public RFEM6Adapter(bool active = false)
+        public RFEM6Adapter(string filePath = "", bool active = false)
         {
 
             // The Adapter constructor can be used to configure the Adapter behaviour.
@@ -66,7 +67,7 @@ namespace BH.Adapter.RFEM6
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.FullPush; // Adapter `Push` Action simply calls "Create" method.
             //m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateOnly;
             m_AdapterSettings.OnlyUpdateChangedObjects = false; // Setting this to true causes a Stackoverflow in some cases from the HashComparer called from the base FullCRUD.
-            m_AdapterSettings.CreateOnly_DistinctObjects = false; 
+            m_AdapterSettings.CreateOnly_DistinctObjects = false;
 
             AddAdapterModules();
 
@@ -76,16 +77,18 @@ namespace BH.Adapter.RFEM6
 
             AdapterIdFragmentType = typeof(RFEM6ID);
 
+            m_filepath = filePath;
+
         }
 
         /***************************************************/
         /**** Private  Fields                           ****/
         /***************************************************/
 
-        public Dictionary<Loadcase, Dictionary<String,int>> m_LoadcaseLoadIdDict = new Dictionary<Loadcase, Dictionary<String, int>>(new LoadCaseComparer());
+        public string m_filepath = "";
+
+        public Dictionary<Loadcase, Dictionary<String, int>> m_LoadcaseLoadIdDict = new Dictionary<Loadcase, Dictionary<String, int>>(new LoadCaseComparer());
         public Dictionary<Panel, int> m_PanelIDdict = new Dictionary<Panel, int>(new RFEMPanelComparer());
-
-
 
         /***************************************************/
         /**** Private Methods                           ****/
@@ -100,19 +103,65 @@ namespace BH.Adapter.RFEM6
 
         public void Connect()
         {
+            if (ApplicationIsRunning())
+            {
+                string modelUrl = "";
 
-            string modelUrl = m_Application.get_active_model();
+                try
+                {
+                    modelUrl=m_Application.open_model(m_filepath);
 
-            // connects to RFEM6/RSTAB9 model
-            m_Model = new RfemModelClient(Binding, new EndpointAddress(modelUrl));
+                }
+                catch
+                {
+                    modelUrl=GetOpenModel();
 
-            // var tst= m_Model.get_section(1);
+                }
+
+                 //modelUrl = m_Application.get_active_model();
+                // connects to RFEM6/RSTAB9 model
+                m_Model = new RfemModelClient(Binding, new EndpointAddress(modelUrl));
+                //m_Model.get_model_settings_and_options().global_axes_orientation=model_settings_and_options_global_axes_orientation_type.E_GLOBAL_AXES_ORIENTATION_ZUP;
+                //m_Model.get_model_settings_and_options().global_axes_orientationSpecified = true;
+
+            }
+            else
+            {
+
+                BH.Engine.Base.Compute.RecordWarning("RFEM6 application is not running. Please start RFEM6 and open the application on your system.");
+
+            }
         }
 
         public void Disconnect()
         {
             m_Model.close_connection();
             m_Model = null;
+        }
+
+        public bool ApplicationIsRunning()
+        {
+            if (Process.GetProcessesByName("RFEM6").Count() > 0) return true;
+            else return false;
+        }
+
+        public string GetOpenModel()
+        {
+
+            string modelUrl = "";
+
+            try
+            {
+                modelUrl = m_Application.get_active_model();
+                return modelUrl;
+            }
+            catch
+            {
+                string dateTimeSignature = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                string modelName = $"New_Model_{dateTimeSignature}";
+                modelUrl = m_Application.new_model(modelName);
+                return modelUrl;
+            }
         }
 
         //RFEM stuff ----------------------------
@@ -123,7 +172,7 @@ namespace BH.Adapter.RFEM6
         {
             get
             {
-                BasicHttpBinding binding = new BasicHttpBinding { SendTimeout = new TimeSpan(0, 0, 180), UseDefaultWebProxy = true,MaxReceivedMessageSize= 2147483647 };
+                BasicHttpBinding binding = new BasicHttpBinding { SendTimeout = new TimeSpan(0, 0, 180), UseDefaultWebProxy = true, MaxReceivedMessageSize = 2147483647 };
                 return binding;
             }
         }

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -60,9 +60,10 @@ namespace BH.Adapter.RFEM6
         [Description("Adapter for RFEM6.")]
         [Input("filePath", "Input the optional file path to RFEM model. Default is to use the currently running instance")]
         [Output("The created RFEM6 adapter.")]
-        [PreviousVersion("8.3", "BH.Adapter.RFEM6Adapter.RFEM6Adapter(System.Boolean)")]
+        [PreviousVersion("8.3", "BH.Adapter.RFEM6.RFEM6Adapter(System.Boolean)")]
         public RFEM6Adapter(string filePath = "", bool active = false)
         {
+
             if (active)
             {
                 // The Adapter constructor can be used to configure the Adapter behaviour.

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -56,7 +56,7 @@ namespace BH.Adapter.RFEM6
         /***************************************************/
         /**** Constructors                              ****/
         /***************************************************/
-
+        [PreviousVersion("8.2", "BH.Adapter.RFEM6Adapter.RFEM6Adapter(bool)")]
         [Description("Adapter for RFEM6.")]
         [Output("The created RFEM6 adapter.")]
         public RFEM6Adapter(string filePath = "", bool active = false)

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -56,7 +56,8 @@ namespace BH.Adapter.RFEM6
         /***************************************************/
         /**** Constructors                              ****/
         /***************************************************/
-        [PreviousVersion("8.3", "BH.Adapter.RFEM6Adapter.RFEM6Adapter(bool)")]
+            
+        [PreviousVersion("8.3", "BH.Adapter.RFEM6Adapter.RFEM6Adapter(System.Boolean)")]
         [Description("Adapter for RFEM6.")]
         [Output("The created RFEM6 adapter.")]
         public RFEM6Adapter(string filePath = "", bool active = false)

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -123,7 +123,7 @@ namespace BH.Adapter.RFEM6
             else
             {
 
-                BH.Engine.Base.Compute.RecordWarning("RFEM6 application is not running. Please start RFEM6 and open the application on your system.");
+                BH.Engine.Base.Compute.RecordWarning("RFEM6 application is not running. Please start RFEM6 on your system.");
 
             }
         }

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -57,9 +57,10 @@ namespace BH.Adapter.RFEM6
         /**** Constructors                              ****/
         /***************************************************/
             
-        [PreviousVersion("8.3", "BH.Adapter.RFEM6Adapter.RFEM6Adapter(System.Boolean)")]
         [Description("Adapter for RFEM6.")]
+        [Input("filePath", "Input the optional file path to RFEM model. Default is to use the currently running instance")]
         [Output("The created RFEM6 adapter.")]
+        [PreviousVersion("8.3", "BH.Adapter.RFEM6Adapter.RFEM6Adapter(System.Boolean)")]
         public RFEM6Adapter(string filePath = "", bool active = false)
         {
             if (active)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #20 

This PR addresses the issue of selecting which RFEM model to interact with when multiple models are open. The following enhancements have been implemented:

- **Model Selection:** Added an option in the adapter settings for users to define the name (and path) of the model file to interact with. This gives users more control, especially when multiple models are open.
- **Application Not Running:** If the RFEM application is not running, the adapter now gives a warning and a helpful hint about what to do.
- **No Model Open:** If no model is open, the adapter will open a new model when a push operation is triggered.
- **File Path Handling:** When a file path is provided, the adapter will open the specified model.



### Test files
<!-- Link to test files to validate the proposed changes -->

Link to test files --> [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FRFEM6%5FTookit%2FIssues%2FRFEM6%5FToolkit%2D%2320%2DDefineToWhichModelShouldBePusheOrPulled)

**Test Procedure:**

Download all three files from the link above. Open the GH file and add the path to both the test1 and test2 RFEM6 file in the GH file. 

1. Push when RFEM6 is closed: A warning message should be displayed.
2. Push when RFEM6 is open but no model has been opened: The model should be initialized and the push should be performed. This should work both when when a model file path has been set and when it has not. 
3. Push into a dedicated model: Open both RFEM6 test models and verify that pushing into each model works as expected.
4. Pull from a dedicated model: Similar to step 3, but for pulling data instead of pushing.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Updated `RFEM6Adapter` constructor to accept an optional `filePath` parameter and improved model connection handling, including more robust checks for application state and model opening behavior.
-  Ensured that model connection logic is more robust.
