### PR TITLE
Fail to Push Panels

### DIFF
--- a/RFEM6_Adapter/Comparers/PanelComparer.cs
+++ b/RFEM6_Adapter/Comparers/PanelComparer.cs
@@ -50,9 +50,7 @@ namespace BH.Adapter.RFEM6
 
         public bool Equals(Panel panel0, Panel panel1)
         {
-            Polyline polyline0 = BH.Engine.Geometry.Create.Polyline(panel0.ExternalEdges.ToList().Select(s => s.Curve as Line).ToList()).Close();
-            Polyline polyline1 = BH.Engine.Geometry.Create.Polyline(panel1.ExternalEdges.ToList().Select(s => s.Curve as Line).ToList()).Close();
-            if (polyline0.Centroid().Distance(polyline1.Centroid()) <0.001) return true;
+            if (panel0.Centroid().Distance(panel1.Centroid()) <0.001) return true;
             return false;
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->


Closes #117 

<!-- Add short description of what has been fixed -->
When pushing panels into model with existing panels the comparison method for `Panel`s throws an error. 


### Test files
<!-- Link to test files to validate the proposed changes -->
[Link](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/RFEM6_Tookit/Issues/%23117_fail_to_push_panels.gh?csf=1&web=1&e=tqo6Wa)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Updated comparison method for a `Panel`;

### Additional comments
<!-- As required -->
For testint simply push the geometry into RFEM6. All panesl should apear in RFEM6. 
