### PR TITLE
Pulling Bars in Reversed Orientation

### DIFF
--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Bar.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Geometry/Bar.cs
@@ -63,11 +63,12 @@ namespace BH.Adapter.RFEM6
             foreach (var rfMember in allRfMembers)
             {
 
+               
                 Node node0 = null;
-                nodes.TryGetValue(rfMember.nodes[0], out node0);
+                nodes.TryGetValue(rfMember.node_start, out node0);
 
                 Node node1 = null;
-                nodes.TryGetValue(rfMember.nodes[1], out node1);
+                nodes.TryGetValue(rfMember.node_end, out node1);
 
                 ISectionProperty section = null;
                 sections.TryGetValue(rfMember.section_end, out section);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #123 

<!-- Add short description of what has been fixed -->
The RFEM6 API supports multiple methods for reading bar end data. The method previously used was retrieving the end nodes in the wrong order. This issue has been resolved in this pull request.


### Test files
<!-- Link to test files to validate the proposed changes -->
[Link to file](https://burohappold.sharepoint.com/:f:/s/BHoM/Er4iBwC2xV1Pj-OXtAskTv0Bl7LfaB6na3U2URJH5aOptA?e=lyHrhj)
For testing, please open the linked file and retrieve all bars.
After that, filter through the assigned bars and verify whether the bar end node IDs match those in RFEM6.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- The methods for reading bar end nodes have been replaced.


