### PR TITLE
Error Handling For Bar Result Reading 

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Result/BarResults.cs
@@ -36,52 +36,74 @@ namespace RFEM_Toolkit_Test.Elements
 {
 
 
-	public class BarResultTestClass
+    public class BarResultTestClass
 
-	{
+    {
 
-		RFEM6Adapter adapter;
+        RFEM6Adapter adapter;
 
-		//[TearDown]
-		//public void TearDown()
-		//{
-		//	adapter.Wipeout();
-		//}
+        //[TearDown]
+        //public void TearDown()
+        //{
+        //	adapter.Wipeout();
+        //}
 
-		[OneTimeSetUp]
-		public void InitializeRFEM6Adapter()
-		{
-			adapter = new RFEM6Adapter(active:true);
+        [OneTimeSetUp]
+        public void InitializeRFEM6Adapter()
+        {
+            adapter = new RFEM6Adapter(active: true);
 
-		}
+        }
 
-		[Test]
-		public void ReadResult()
-		{
-			List<LoadCombination?> loadCombList = adapter.Pull(new FilterRequest() { Type = typeof(LoadCombination) }).Select(l=> l as LoadCombination).ToList();
+        [Test]
+        public void ReadResult()
+        {
+            List<LoadCombination?> loadCombList = adapter.Pull(new FilterRequest() { Type = typeof(LoadCombination) }).Select(l => l as LoadCombination).ToList();
 
-			Loadcase loadcase1 = new Loadcase() { Name = "LC1", Nature = LoadNature.Dead, Number = 1 };
-			LoadCombination loadCombination = new LoadCombination { Name = "LoadCombination1", Number = 1 };
+            Loadcase loadcase1 = new Loadcase() { Name = "LC1", Nature = LoadNature.Dead, Number = 1 };
+            LoadCombination loadCombination = new LoadCombination { Name = "LoadCombination1", Number = 1 };
 
-			BarResultRequest request = new BarResultRequest();
+            BarResultRequest request = new BarResultRequest();
 
-			request.ResultType = BarResultType.BarForce;
-			request.DivisionType = DivisionType.EvenlyDistributed;
-			request.Divisions = 3;
-			request.Cases = new List<Object> { loadCombList.First() };
-			//request.Cases = new List<Object> {1};
-			request.Modes = new List<string>();
-			request.ObjectIds = new List<object> {1};
-			//request.ObjectIds = new List<object> {1,2,3,4};
+            request.ResultType = BarResultType.BarForce;
+            request.DivisionType = DivisionType.EvenlyDistributed;
+            request.Divisions = 3;
+            request.Cases = new List<Object> { loadCombList.First() };
+            //request.Cases = new List<Object> {1};
+            request.Modes = new List<string>();
+            request.ObjectIds = new List<object> { 1 };
+            //request.ObjectIds = new List<object> {1,2,3,4};
 
-			var obj = adapter.Pull(request);
+            var obj = adapter.Pull(request);
 
-			obj.First();
+            obj.First();
 
-		}
+        }
+
+        [Test]
+        public void ReadResult2()
+        {
+            List<LoadCombination?> loadCombList = adapter.Pull(new FilterRequest() { Type = typeof(LoadCombination) }).Select(l => l as LoadCombination).ToList();
+            List<LoadCombination?> relevantLoadComb = loadCombList.Take(38).ToList();
+
+            BarResultRequest request = new BarResultRequest();
+
+            request.ResultType = BarResultType.BarForce;
+            request.DivisionType = DivisionType.EvenlyDistributed;
+            request.Divisions = 2;
+            request.Cases = new List<Object> {relevantLoadComb.First()};
+            request.Modes = new List<string>();
+            //request.ObjectIds = new List<object> { 1 };
+            //request.ObjectIds = new List<object> {1,2,3,4};
+
+            var obj = adapter.Pull(request);
+
+
+            var obj_first = obj.First();
+        }
 
 
 
-	}
+    }
 }
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -19,171 +19,191 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using BH.oM.Adapter;
-using BH.oM.Structure.Elements;
-using BH.oM.Structure.Constraints;
-
-using rfModel = Dlubal.WS.Rfem6.Model;
-using BH.oM.Adapters.RFEM6;
-using BH.oM.Structure.Loads;
-using Dlubal.WS.Rfem6.Model;
-using System.Xml.Linq;
 using BH.Engine.Base;
+using BH.Engine.Spatial;
+using BH.oM.Adapter;
+using BH.oM.Adapters.RFEM6;
 using BH.oM.Analytical.Results;
+using BH.oM.Structure.Constraints;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Loads;
+using BH.oM.Structure.MaterialFragments;
 using BH.oM.Structure.Requests;
 using BH.oM.Structure.Results;
+using Dlubal.WS.Rfem6.Model;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Configuration;
 using System.Globalization;
-using System.ComponentModel;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Text;
+using System.Xml.Linq;
+using rfModel = Dlubal.WS.Rfem6.Model;
 
 namespace BH.Adapter.RFEM6
 {
-	public partial class RFEM6Adapter
-	{
+    public partial class RFEM6Adapter
+    {
 
-		public IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
-		{
+        public IEnumerable<IResult> ReadResults(BarResultRequest request, ActionConfig actionConfig)
+        {
+            
 
+            //Warnings 
+            BH.Engine.Base.Compute.RecordWarning($"Divisions are set to {request.Divisions}. Division functionality has not been implemented yet in RFEM6_Toolkit. Currently, the number of divisions depends solely on what RFEM6 provides and can vary significantly based on the load type on the corresponding Bar/Member and the DivisionType.");
 
-			//Warnings 
-			BH.Engine.Base.Compute.RecordWarning($"Divisions are set to {request.Divisions}. Division functionality has not been implemented yet in RFEM6_Toolkit. Currently, the number of divisions depends solely on what RFEM6 provides and can vary significantly based on the load type on the corresponding Bar/Member and the DivisionType.");
+            if (request.Cases.Where(c => c is string).ToList().Count > 0) { BH.Engine.Base.Compute.RecordWarning("At least one instance of the Case input is neither of type LoadCase nor LoadCombination. The set CaseIds will be assumed to be LoadCase IDs for now."); }
+            ;
 
-			if (request.Cases.Where(c=> c is string).ToList().Count>0) { BH.Engine.Base.Compute.RecordWarning("At least one instance of the Case input is neither of type LoadCase nor LoadCombination. The set CaseIds will be assumed to be LoadCase IDs for now."); };
+            //RFEM Specific Stuff
+            m_Model.use_detailed_member_results(true);
 
-			//RFEM Specific Stuff
-			m_Model.use_detailed_member_results(true);
+            // Loading of Member And LoadCase Ids
+            List<int> memberIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
 
-			// Loading of Member And LoadCase Ids
-			List<int> memberIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
+            // Definition of Object Locations for Members
+            object_location[] objectLocations = memberIds.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_MEMBER, no = n, parent_no = 0 }).ToArray();
 
-			// Definition of Object Locations for Members
-			object_location[] objectLocations = memberIds.Select(n => new object_location() { type = object_types.E_OBJECT_TYPE_MEMBER, no = n, parent_no = 0 }).ToArray();
-
-			//ResultList
-			List<IResult> resultList = new List<IResult>();
-
-
-			foreach (var c in request.Cases)
-			{
-				int cId = 0;
-
-				if (c is Loadcase)
-				{
-					cId = (c as Loadcase).Number;
-
-				}
-				else if (c is LoadCombination)
-				{
-
-					cId = (c as LoadCombination).Number;
-
-				}
-				else
-				{
-
-					cId = Int32.Parse(c.ToString());
-				}
+            //ResultList
+            List<IResult> resultList = new List<IResult>();
 
 
+            foreach (var c in request.Cases)
+            {
+                int cId = 0;
 
-				//Loading resulst from RFEM
-				INotifyPropertyChanged[] barResults = new INotifyPropertyChanged[1];
+                if (c is Loadcase)
+                {
+                    cId = (c as Loadcase).Number;
 
-				var loadingType = c is LoadCombination ? case_object_types.E_OBJECT_TYPE_LOAD_COMBINATION : case_object_types.E_OBJECT_TYPE_LOAD_CASE;
-				switch (request.ResultType)
-				{
+                }
+                else if (c is LoadCombination)
+                {
 
-					case BarResultType.BarForce:
-						barResults = m_Model.get_results_for_members_internal_forces(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
-						break;
-					case BarResultType.BarDisplacement:
-						barResults = m_Model.get_results_for_members_global_deformations(loadingType, cId, objectLocations);
-						break;
-					case BarResultType.BarDeformation:
-						barResults = m_Model.get_results_for_members_local_deformations(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
-						break;
-					case BarResultType.BarStrain:
-						barResults = m_Model.get_results_for_members_strains(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
-						break;
-					default:
-						BH.Engine.Base.Compute.RecordError($"The pull result types of type {request.ResultType} has not been developed Yet");
-						return null;
+                    cId = (c as LoadCombination).Number;
 
-				}
+                }
+                else
+                {
 
-				//Grouping of Internal Forces grouped by Member No
-				var memberInternalForceGroup = barResults.GroupBy(r => Int32.Parse(r.PropertyValue("row.member_no").ToString()));
+                    cId = Int32.Parse(c.ToString());
+                }
 
 
-				//Results processing memberwise
-				foreach (IGrouping<int, INotifyPropertyChanged> member in memberInternalForceGroup)
-				{
-					//Ignore Results that do now have a valied ID
-					if (member.Key == 0) continue;
 
-					//Determine Member length
-					String lengthAsString = member.ToList()[0].PropertyValue("row.specification").ToString().Split(new[] { "L : ", " m" }, StringSplitOptions.None)[1];
-					double memberLength = double.Parse(lengthAsString, CultureInfo.InvariantCulture);// Member Length in SI unit m;
+                //Loading resulst from RFEM
+                INotifyPropertyChanged[] barResults = new INotifyPropertyChanged[1];
 
-					var memberSegmentValues = member.ToList();
+                var loadingType = c is LoadCombination ? case_object_types.E_OBJECT_TYPE_LOAD_COMBINATION : case_object_types.E_OBJECT_TYPE_LOAD_CASE;
+                switch (request.ResultType)
+                {
+                    
+                    case BarResultType.BarForce:
+                        barResults = m_Model.get_results_for_members_internal_forces(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
+                        break;
+                    case BarResultType.BarDisplacement:
+                        barResults = m_Model.get_results_for_members_global_deformations(loadingType, cId, objectLocations);
+                        break;
+                    case BarResultType.BarDeformation:
+                        barResults = m_Model.get_results_for_members_local_deformations(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
+                        break;
+                    case BarResultType.BarStrain:
+                        barResults = m_Model.get_results_for_members_strains(loadingType, cId, objectLocations, axes_type.MEMBER_AXES);
+                        break;
+                    default:
+                        BH.Engine.Base.Compute.RecordError($"The pull result types of type {request.ResultType} has not been developed Yet");
+                        return null;
 
-					//If we are looking for exterme Values
-					if (request.DivisionType == DivisionType.ExtremeValues)
-					{
+                }
 
-						memberSegmentValues = member.SkipWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
-						memberSegmentValues = memberSegmentValues.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Total")).ToList();
+                //Grouping of Internal Forces grouped by Member No
+                var memberInternalForceGroup = barResults.GroupBy(r => Int32.Parse(r.PropertyValue("row.member_no").ToString()));
 
-					}
 
-					else
-					{
-						memberSegmentValues = memberSegmentValues.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
+                //Results processing memberwise
+                foreach (IGrouping<int, INotifyPropertyChanged> member in memberInternalForceGroup)
+                {
+                    //Ignore Results that do now have a valied ID
+                    if (member.Key == 0) continue;
 
-					}
+                    //Determine Member length
+                    Dictionary<int, Bar> barDictionary = new Dictionary<int, Bar>();
+                    double memberLength = 0;
+                    try
+                    {
 
-					int corrective = (request.ResultType == BarResultType.BarDisplacement || request.ResultType == BarResultType.BarDeformation) ? 0 : 2;
-					// important do to enable processing of Deformations due to the |u|
-					if (memberSegmentValues?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
-					{
-						memberSegmentValues = memberSegmentValues.Skip(2).ToList();
-						//corrective = 0;
-					}
+                        if (barDictionary.Keys.Contains(member.Key))
+                        {
+                            memberLength = barDictionary[member.Key].Length();
+                            continue;
+                        }
 
-					//Conversion for every segment of member
-					foreach (var e in memberSegmentValues)
-					{
+                        String lengthAsString = member.ToList()[0].PropertyValue("row.specification").ToString().Split(new[] { "L : ", " m" }, StringSplitOptions.None)[1];
+                        memberLength = double.Parse(lengthAsString, CultureInfo.InvariantCulture);// Member Length in SI unit m;
+                    }
+                    catch
+                    {
+                        barDictionary = this.GetCachedOrReadAsDictionary<int, Bar>();
+                        memberLength = barDictionary[member.Key].Length();
+                    }
 
-						var location = Double.Parse(e.PropertyValue("row.location").ToString());
-						var memberNumber = Int32.Parse(e.PropertyValue("row.member_no").ToString());
-						var props = e.PropertyValue("row").GetType().GetProperties();
-						List<int> accesList = new List<int>() { 10 - corrective, 12 - corrective, 14 - corrective, 16 - corrective, 18 - corrective, 20 - corrective };
-						var accessedlist = accesList.Select(a => props.ToList()[a]);
-						Dictionary<string, double> val = new[] {
-							(10-corrective, "x"), (12-corrective, "y"), (14-corrective, "z"),
-							(16-corrective, "rx"), (18-corrective, "ry"), (20-corrective, "rz")
-						}.ToDictionary(p => p.Item2, p => Double.Parse(
-							e.PropertyValue($"row.{props[p.Item1].Name}").ToString()
-						));
 
-						var result = val.Values.ToList().FromRFEM(cId, memberLength, location, memberNumber, request.ResultType);
-						resultList.Add(result);
-					}
 
-				}
-			}
+                    var memberSegmentValues = member.ToList();
 
-			return resultList;
+                    //If we are looking for exterme Values
+                    if (request.DivisionType == DivisionType.ExtremeValues)
+                    {
 
-		}
+                        memberSegmentValues = member.SkipWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
+                        memberSegmentValues = memberSegmentValues.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Total")).ToList();
 
-	}
+                    }
+
+                    else
+                    {
+                        memberSegmentValues = memberSegmentValues.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
+
+                    }
+
+                    int corrective = (request.ResultType == BarResultType.BarDisplacement || request.ResultType == BarResultType.BarDeformation) ? 0 : 2;
+                    // important do to enable processing of Deformations due to the |u|
+                    if (memberSegmentValues?.First()?.PropertyValue("row.deformation_label")?.ToString()?.Contains("|u|") ?? false)
+                    {
+                        memberSegmentValues = memberSegmentValues.Skip(2).ToList();
+                        //corrective = 0;
+                    }
+
+                    //Conversion for every segment of member
+                    foreach (var e in memberSegmentValues)
+                    {
+
+                        var location = Double.Parse(e.PropertyValue("row.location").ToString());
+                        var memberNumber = Int32.Parse(e.PropertyValue("row.member_no").ToString());
+                        var props = e.PropertyValue("row").GetType().GetProperties();
+                        List<int> accesList = new List<int>() { 10 - corrective, 12 - corrective, 14 - corrective, 16 - corrective, 18 - corrective, 20 - corrective };
+                        var accessedlist = accesList.Select(a => props.ToList()[a]);
+                        Dictionary<string, double> val = new[] {
+                            (10-corrective, "x"), (12-corrective, "y"), (14-corrective, "z"),
+                            (16-corrective, "rx"), (18-corrective, "ry"), (20-corrective, "rz")
+                        }.ToDictionary(p => p.Item2, p => Double.Parse(
+                            e.PropertyValue($"row.{props[p.Item1].Name}").ToString()
+                        ));
+
+                        var result = val.Values.ToList().FromRFEM(cId, memberLength, location, memberNumber, request.ResultType);
+                        resultList.Add(result);
+                    }
+
+                }
+            }
+
+            return resultList;
+
+        }
+
+    }
 }
 
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #125 

<!-- Add short description of what has been fixed -->
When pulling BarResults from the linked RFEM6 file, an error is thrown. The problem is likely that the length attribute is not reliably assigned to all beams in RFEM6. This issue should be handled using a try/except block, for example.

### Test files
<!-- Link to test files to validate the proposed changes -->
[GH-File](https://burohappold.sharepoint.com/:u:/s/BHoM/EehNl2hIlN9Mp0rm861mOrwB0B6Y7gZdq17wI32I2zBCXQ?e=Gikt04)
[RFEM6-file](https://burohappold.sharepoint.com/:u:/s/BHoM/EQqrq_9jXOZIj-qRxCfN9D0BaEHgNQ8Cl3rt4biFuFuVkw?e=AnycBe)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- A try/except block was implemented to capture potential errors when reading the length attribute from members.
- The BHoM caching system was used to reduce computation time.

### Additional comments
<!-- As required -->
Please perform the following steps:

1. Open the RFEM6 file and run calculations for all load combinations and load cases.
2. Open the Grasshopper (GH) file.
3. Pull load cases into the GH file.
4. Pull bar results into the GH file.

Expected Result:
No errors should be thrown when pulling objects.
