### PR TITLE
Push of Free Polygonal Loads

### DIFF
--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Panel/Panel.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Geometry/Panel/Panel.cs
@@ -116,12 +116,12 @@ namespace RFEM_Toolkit_Test.Elements
         public void PushPullPanel()
         {
 
-            adapter.Push(new List<Panel>() { panel1});
+            //adapter.Push(new List<Panel>() { panel1});
 
             //// Pull it
-            //FilterRequest panelFilter = new FilterRequest() { Type = typeof(Panel) };
-            //var panelPulled = adapter.Pull(panelFilter).ToList();
-            //Panel pp = (Panel)panelPulled[0];
+            FilterRequest panelFilter = new FilterRequest() { Type = typeof(Panel) };
+            var panelPulled = adapter.Pull(panelFilter).ToList();
+            Panel pp = (Panel)panelPulled[0];
 
             //// Check
             //Assert.IsNotNull(pp);

--- a/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/UniformlyDistributedAreaLoad.cs
+++ b/.ci/unit-tests/RFEM_Toolkit_Test/BHoMDataStructure/Loading/UniformlyDistributedAreaLoad.cs
@@ -142,7 +142,7 @@ namespace RFEM_Toolkit_Test.Elements
         [SetUp]
         public void SetUp()
         {
-            adapter.Push(new List<Panel>() { panel1, panel2, panel3 });
+            //adapter.Push(new List<Panel>() { panel1, panel2, panel3 });
         }
 
 
@@ -268,7 +268,19 @@ namespace RFEM_Toolkit_Test.Elements
             Assert.True(this.reverseAreaLoadList[i].Axis.Equals(areaLoadList[i].Axis));
         }
 
+        [Test]
+        public void PullUniformlyDistributedLoad()
+        {
 
+            //Act
+
+            // Push
+
+            // Pull
+            FilterRequest loadFilter = new FilterRequest() { Type = typeof(AreaUniformlyDistributedLoad) };
+            List<AreaUniformlyDistributedLoad> areaLoadList = adapter.Pull(loadFilter).ToList().Select(p => (AreaUniformlyDistributedLoad)p).ToList();
+            var a = areaLoadList.First();
+        }
     }
 
 

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -239,15 +239,20 @@ namespace BH.Adapter.RFEM6
 
         private void CreateLoad_Polygon(AreaUniformlyDistributedLoad bhLoad)
         {
-            UpdateLoadIdDictionary(bhLoad);
-            //Call Panel Load Methond to update the Panel ID Dictionary
-            this.GetCachedOrReadAsDictionary<int, Panel>();
-            int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
-            free_polygon_load rfemAreaLoad = (bhLoad as AreaUniformlyDistributedLoad).ToRFEM6_Polygon(id);
-            var currrSurfaceIds = (bhLoad as AreaUniformlyDistributedLoad).Objects.Elements.ToList().Select(e => m_PanelIDdict[e as Panel]).ToArray();
-            rfemAreaLoad.surfaces = currrSurfaceIds;
-            m_Model.set_free_polygon_load(bhLoad.Loadcase.Number, rfemAreaLoad);
+            try
+            {
+                UpdateLoadIdDictionary(bhLoad);
+                //Call Panel Load Methond to update the Panel ID Dictionary
+                this.GetCachedOrReadAsDictionary<int, Panel>();
+                int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
+                free_polygon_load rfemAreaLoad = (bhLoad as AreaUniformlyDistributedLoad).ToRFEM6_Polygon(id);
+                var currrSurfaceIds = (bhLoad as AreaUniformlyDistributedLoad).Objects.Elements.ToList().Select(e => m_PanelIDdict[e as Panel]).ToArray();
+                rfemAreaLoad.surfaces = currrSurfaceIds;
+                m_Model.set_free_polygon_load(bhLoad.Loadcase.Number, rfemAreaLoad);
 
+            } catch {
+                BH.Engine.Base.Compute.RecordError($"The creation of {bhLoad} failed.\nA potential cause is that the applied polygon is non-planar or not parallel to the XY, YZ, or ZX plane.");
+            }
         }
 
         private void CreateLoad(BarUniformlyDistributedLoad bhLoad)

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -250,8 +250,8 @@ namespace BH.Adapter.RFEM6
                 rfemAreaLoad.surfaces = currrSurfaceIds;
                 m_Model.set_free_polygon_load(bhLoad.Loadcase.Number, rfemAreaLoad);
 
-            } catch {
-                BH.Engine.Base.Compute.RecordError($"The creation of {bhLoad} failed.\nA potential cause is that the applied polygon is non-planar or not parallel to the XY, YZ, or ZX plane.");
+            } catch (Exception ex) {
+                BH.Engine.Base.Compute.RecordError($"The creation of {bhLoad} failed.\nA potential cause is that the applied polygon is non-planar or not parallel to the XY, YZ, or ZX plane.\nException: {ex.Message}\nStackTrace: {ex.StackTrace}");
             }
         }
 

--- a/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Create/BHoMDataStructure/Loading/Load.cs
@@ -61,6 +61,10 @@ namespace BH.Adapter.RFEM6
 
                 if (bhLoad is AreaUniformlyDistributedLoad)
                 {
+                    if (bhLoad.CustomData.Values.Any(l=>l is Polygon)) {
+                        CreateLoad_Polygon(bhLoad as AreaUniformlyDistributedLoad);
+                        continue;
+                    }
                     CreateLoad(bhLoad as AreaUniformlyDistributedLoad);
                     continue;
                 }
@@ -230,6 +234,19 @@ namespace BH.Adapter.RFEM6
             var currrSurfaceIds = (bhLoad as AreaUniformlyDistributedLoad).Objects.Elements.ToList().Select(e => m_PanelIDdict[e as Panel]).ToArray();
             rfemAreaLoad.surfaces = currrSurfaceIds;
             m_Model.set_surface_load(bhLoad.Loadcase.Number, rfemAreaLoad);
+
+        }
+
+        private void CreateLoad_Polygon(AreaUniformlyDistributedLoad bhLoad)
+        {
+            UpdateLoadIdDictionary(bhLoad);
+            //Call Panel Load Methond to update the Panel ID Dictionary
+            this.GetCachedOrReadAsDictionary<int, Panel>();
+            int id = m_LoadcaseLoadIdDict[bhLoad.Loadcase][bhLoad.GetType().Name];
+            free_polygon_load rfemAreaLoad = (bhLoad as AreaUniformlyDistributedLoad).ToRFEM6_Polygon(id);
+            var currrSurfaceIds = (bhLoad as AreaUniformlyDistributedLoad).Objects.Elements.ToList().Select(e => m_PanelIDdict[e as Panel]).ToArray();
+            rfemAreaLoad.surfaces = currrSurfaceIds;
+            m_Model.set_free_polygon_load(bhLoad.Loadcase.Number, rfemAreaLoad);
 
         }
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -155,8 +155,6 @@ namespace BH.Adapter.RFEM6
             foreach (rfModel.free_polygon_load polygonLoad in foundPolygonLoad_)
             {
                 List<Panel> panels = polygonLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
-                Loadcase loadcase = loadCaseMap[polygonLoad.load_case];
-
                 if (!(polygonLoad.load_distribution is rfModel.free_polygon_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
                 {
                     Engine.Base.Compute.RecordNote("The current RFEM6 includes Surfaceloads with a non-uniformal load distributeion, these Loads will not be pulled.");

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -186,7 +186,6 @@ namespace BH.Adapter.RFEM6
             foreach (rfModel.free_polygon_load polLoad in foundPolygonLoad)
             {
                 List<Panel> panels = polLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
-                Loadcase loadcase = loadCaseMap[polLoad.load_case];
 
                 if (!(polLoad.load_distribution is rfModel.free_polygon_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
                 {

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -137,7 +137,7 @@ namespace BH.Adapter.RFEM6
 
 				if (!(surfaceLoad.load_distribution is rfModel.surface_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
 				{
-					Engine.Base.Compute.RecordNote("The current RFEM6 includes Surfaceloads with a non-uniformal load distributeion, these Loads will not be pulled.");
+					Engine.Base.Compute.RecordNote("The current RFEM6 includes Surface loads with a non-uniformal load distributeion, these Loads will not be pulled.");
 					continue;
 				}
 
@@ -157,7 +157,7 @@ namespace BH.Adapter.RFEM6
                 List<Panel> panels = polygonLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
                 if (!(polygonLoad.load_distribution is rfModel.free_polygon_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
                 {
-                    Engine.Base.Compute.RecordNote("The current RFEM6 includes Surfaceloads with a non-uniformal load distributeion, these Loads will not be pulled.");
+                    Engine.Base.Compute.RecordNote("The current RFEM6 includes Surface loads with a non-uniformal load distributeion, these Loads will not be pulled.");
                     continue;
                 }
 
@@ -189,7 +189,7 @@ namespace BH.Adapter.RFEM6
 
                 if (!(polLoad.load_distribution is rfModel.free_polygon_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
                 {
-                    Engine.Base.Compute.RecordNote("The current RFEM6 includes Surfaceloads with a non-uniformal load distributeion, these Loads will not be pulled.");
+                    Engine.Base.Compute.RecordNote("The current RFEM6 includes Surface loads with a non-uniformal load distributeion, these Loads will not be pulled.");
                     continue;
                 }
 

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -169,37 +169,7 @@ namespace BH.Adapter.RFEM6
             return loads;
 		}
 
-        private List<ILoad> ReadPolygonLoad(List<string> ids = null)
-        {
-            List<ILoad> loads = new List<ILoad>();
-
-            //Find all possible Load cases
-            Dictionary<int, Loadcase> loadCaseMap = this.GetCachedOrReadAsDictionary<int, Loadcase>();
-            Dictionary<int, Panel> panelMap = this.GetCachedOrReadAsDictionary<int, Panel>();
-
-            rfModel.object_with_children[] numbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_FREE_POLYGON_LOAD);
-
-            //IEnumerable<rfModel.surface_load> foundSurfaceLoad = numbers.ToList().Select(n => m_Model.get_surface_load(n.children[0], n.no));
-            IEnumerable<rfModel.free_polygon_load> foundPolygonLoad = numbers.SelectMany(n => n.children.Select(child => m_Model.get_free_polygon_load(child, n.no)));
-
-            foundPolygonLoad = foundPolygonLoad.OrderBy(n => n.load_case).ThenBy(t => t.no);
-            foreach (rfModel.free_polygon_load polLoad in foundPolygonLoad)
-            {
-                List<Panel> panels = polLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
-
-                if (!(polLoad.load_distribution is rfModel.free_polygon_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
-                {
-                    Engine.Base.Compute.RecordNote("The current RFEM6 includes Surface loads with a non-uniformal load distributeion, these Loads will not be pulled.");
-                    continue;
-                }
-
-                loads.Add(polLoad.FromRFEM(loadCaseMap[polLoad.load_case], panels));
-
-            }
-
-            return loads;
-        }
-
+   
 
         private List<ILoad> ReadFreeLineLoad(List<string> ids = null)
 		{

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Loading/Load.cs
@@ -157,7 +157,7 @@ namespace BH.Adapter.RFEM6
                 List<Panel> panels = polygonLoad.surfaces.ToList().Select(s => panelMap[s]).ToList();
                 Loadcase loadcase = loadCaseMap[polygonLoad.load_case];
 
-                if (!(polygonLoad.load_distribution is rfModel.free_polygon_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM)
+                if (!(polygonLoad.load_distribution is rfModel.free_polygon_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM))
                 {
                     Engine.Base.Compute.RecordNote("The current RFEM6 includes Surfaceloads with a non-uniformal load distributeion, these Loads will not be pulled.");
                     continue;

--- a/RFEM6_Adapter/CRUD/Read/IntermediateDatastructure/RFEMLine.cs
+++ b/RFEM6_Adapter/CRUD/Read/IntermediateDatastructure/RFEMLine.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.RFEM6
 
             List<RFEMLine> lineList = new List<RFEMLine>();
 
-            var lineNumbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LINE);
+            var lineNumbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LINE).Where(l => l.no > 0);
             var allRfLInes = lineNumbers.ToList().Select(n => m_Model.get_line(n.no));
             
             //var lineSupportNumbers = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_LINE);

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Panel.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Geometry/Panel.cs
@@ -45,10 +45,6 @@ namespace BH.Adapter.RFEM6
         public static Panel FromRFEM(this rfModel.surface rfSurface, Dictionary<int, Edge> edgeDict, Dictionary<int, ISurfaceProperty> surfaceProperty, HashSet<int> openingIDs, Dictionary<int, RFEMOpening> surfaceOpening)
         {
 
-            //HashSet<int> openingIDs = new HashSet<int>();
-
-            //openingIDDict.TryGetValue(rfPanelNo,out openingIDs);
-
 
             List<int> rfEdgeNumbers = rfSurface.boundary_lines.ToList();
             List<Edge> bhEdges = rfEdgeNumbers.Select(n => edgeDict[n]).ToList();

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -194,7 +194,7 @@ namespace BH.Adapter.RFEM6
             List<double> firstCoordinate = polygonLoad.load_location.ToList().Select(r => r.row.first_coordinate).ToList();
             List<double> secondCoordinate = polygonLoad.load_location.ToList().Select(r => r.row.second_coordinate).ToList();
             List<double> thirdCoordinate = Enumerable.Repeat(0.0, firstCoordinate.Count).ToList();
-            List<Point> loadPolygon = new List<Point>();
+            List<Point> loadPolygon;
 
             switch (polygonLoad.load_projection)
             {

--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -185,6 +185,75 @@ namespace BH.Adapter.RFEM6
             return bhLoad;
         }
 
+        public static AreaUniformlyDistributedLoad FromRFEM(this rfModel.free_polygon_load polygonLoad, Loadcase loadcase, List<Panel> panels)
+        {
+
+            Vector forceDirection;
+            bool isProjected = false;
+            LoadAxis axis = LoadAxis.Global;
+
+            switch (polygonLoad.load_direction)
+            {
+                //case free_polygon_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_GLOBAL_X_TRUE:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(polygonLoad.magnitude_uniform, 0, 0);
+                    break;
+                //case surface_load_load_direction.LOAD_DIRECTION_LOCAL_X:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_LOCAL_X:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(polygonLoad.magnitude_uniform, 0, 0);
+                    axis = LoadAxis.Local;
+                    break;
+
+                //case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_TRUE:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, polygonLoad.magnitude_uniform, 0);
+                    break;
+                //case surface_load_load_direction.LOAD_DIRECTION_LOCAL_Y:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_LOCAL_Y:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, polygonLoad.magnitude_uniform, 0);
+                    axis = LoadAxis.Local;
+                    break;
+
+                //case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_TRUE:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, polygonLoad.magnitude_uniform);
+                    break;
+                //case surface_load_load_direction.LOAD_DIRECTION_LOCAL_Z:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_LOCAL_Z:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, polygonLoad.magnitude_uniform);
+                    axis = LoadAxis.Local;  
+                    break;
+
+                //case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_PROJECTED:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_USER_DEFINED_U_PROJECTED:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(polygonLoad.magnitude_uniform, 0, 0);
+                    isProjected = true;
+                    break;
+
+                //case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_PROJECTED:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_USER_DEFINED_V_PROJECTED:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, polygonLoad.magnitude_uniform, 0);
+                    isProjected = true;
+                    break;
+
+                //case surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_PROJECTED:
+                case free_polygon_load_load_direction.LOAD_DIRECTION_USER_DEFINED_W_PROJECTED:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, polygonLoad.magnitude_uniform);
+                    isProjected = true;
+                    break;
+
+                default:
+                    forceDirection = BH.Engine.Geometry.Create.Vector(0, 0, polygonLoad.magnitude_uniform);
+                    break;
+            }
+
+
+            AreaUniformlyDistributedLoad bhAreaload = BH.Engine.Structure.Create.AreaUniformlyDistributedLoad(loadcase, forceDirection, panels, axis, isProjected, polygonLoad.comment);
+            bhAreaload.SetHashFragment();
+
+            return bhAreaload;
+        }
+
         public static AreaUniformlyDistributedLoad FromRFEM(this rfModel.surface_load surfaceload, Loadcase loadcase, List<Panel> panels)
         {
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -37,7 +37,6 @@ using Dlubal.WS.Rfem6.Model;
 using BH.Engine.Geometry;
 using BH.oM.Geometry;
 using BH.Engine.Spatial;
-using System.Transactions;
 
 namespace BH.Adapter.RFEM6
 {

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -276,21 +276,17 @@ namespace BH.Adapter.RFEM6
 
             Polygon polygon = (Polygon)bhAreaLoad.CustomData.Values.First(p => p is Polygon);
             List<double[]> polygonValues = new List<double[]>();
-            var loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XZ_OR_UW;
-            var fitPlane=polygon.IFitPlane();
+            var fitPlane=polgon.IFitPlane();
             if (fitPlane.Normal.CrossProduct(Plane.XY.Normal).Length() < 0.01)
             {
-                polygonValues=polygon.Vertices.Select(v => new double[] { v.X, v.Y }).ToList();
-                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XY_OR_UV;    
+                polygonValues=polgon.Vertices.Select(v => new double[] { v.X, v.Y }).ToList();
             }
             else if (fitPlane.Normal.CrossProduct(Plane.XZ.Normal).Length() < 0.01)
             {
-                polygonValues=polygon.Vertices.Select(v => new double[] { v.X, v.Z }).ToList();
-                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XZ_OR_UW;
+                polygonValues=polgon.Vertices.Select(v => new double[] { v.X, v.Z }).ToList();
             }
             else {
-                polygonValues=polygon.Vertices.Select(v => new double[] { v.Y, v.Z }).ToList();
-                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_YZ_OR_VW;
+                polygonValues=polgon.Vertices.Select(v => new double[] { v.Y, v.Z }).ToList();
             
             }
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -270,18 +270,21 @@ namespace BH.Adapter.RFEM6
 
             Polygon polgon = (Polygon)bhAreaLoad.CustomData.Values.First(p => p is Polygon);
             List<double[]> polygonValues = new List<double[]>();
+            var loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XZ_OR_UW;
             var fitPlane=polgon.IFitPlane();
             if (fitPlane.Normal.CrossProduct(Plane.XY.Normal).Length() < 0.01)
             {
                 polygonValues=polgon.Vertices.Select(v => new double[] { v.X, v.Y }).ToList();
+                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XY_OR_UV;    
             }
             else if (fitPlane.Normal.CrossProduct(Plane.XZ.Normal).Length() < 0.01)
             {
                 polygonValues=polgon.Vertices.Select(v => new double[] { v.X, v.Z }).ToList();
-
+                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XZ_OR_UW;
             }
             else {
                 polygonValues=polgon.Vertices.Select(v => new double[] { v.Y, v.Z }).ToList();
+                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_YZ_OR_VW;
             
             }
 
@@ -387,7 +390,7 @@ namespace BH.Adapter.RFEM6
                 load_direction = loadDirection,
                 load_directionSpecified = true,
                 load_location = locationPolygons,
-                load_projection = free_polygon_load_load_projection.LOAD_PROJECTION_XY_OR_UV,
+                load_projection = loadProjection,
                 load_projectionSpecified = true
             };
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -294,8 +294,6 @@ namespace BH.Adapter.RFEM6
 
             }
 
-            free_polygon_load_load_location k = new free_polygon_load_load_location() { first_coordinate = 10, second_coordinate = 100 };
-            free_polygon_load_load_location_row r = new free_polygon_load_load_location_row() { row = k };
             free_polygon_load_load_location_row[] locationPolygons = polygonValues.Select((v, i) => new free_polygon_load_load_location_row()
             {
                 no = (i+1),

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -268,6 +268,13 @@ namespace BH.Adapter.RFEM6
         public static rfModel.free_polygon_load ToRFEM6_Polygon(this AreaUniformlyDistributedLoad bhAreaLoad, int loadCaseSpecificLoadId)
         {
 
+            if (bhAreaLoad.Pressure.IsParallel(BH.oM.Geometry.Vector.XAxis)==0 
+                && bhAreaLoad.Pressure.IsParallel(BH.oM.Geometry.Vector.YAxis) == 0
+                && bhAreaLoad.Pressure.IsParallel(BH.oM.Geometry.Vector.ZAxis) == 0)
+            {
+                BH.Engine.Base.Compute.RecordWarning($"Please make sure that the direction of {bhAreaLoad} is axis-aligned.");
+            }
+
             Polygon polgon = (Polygon)bhAreaLoad.CustomData.Values.First(p => p is Polygon);
             List<double[]> polygonValues = new List<double[]>();
             var loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XZ_OR_UW;

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -274,22 +274,22 @@ namespace BH.Adapter.RFEM6
                 BH.Engine.Base.Compute.RecordWarning($"Please make sure that the direction of {bhAreaLoad} is axis-aligned.");
             }
 
-            Polygon polgon = (Polygon)bhAreaLoad.CustomData.Values.First(p => p is Polygon);
+            Polygon polygon = (Polygon)bhAreaLoad.CustomData.Values.First(p => p is Polygon);
             List<double[]> polygonValues = new List<double[]>();
             var loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XZ_OR_UW;
-            var fitPlane=polgon.IFitPlane();
+            var fitPlane=polygon.IFitPlane();
             if (fitPlane.Normal.CrossProduct(Plane.XY.Normal).Length() < 0.01)
             {
-                polygonValues=polgon.Vertices.Select(v => new double[] { v.X, v.Y }).ToList();
+                polygonValues=polygon.Vertices.Select(v => new double[] { v.X, v.Y }).ToList();
                 loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XY_OR_UV;    
             }
             else if (fitPlane.Normal.CrossProduct(Plane.XZ.Normal).Length() < 0.01)
             {
-                polygonValues=polgon.Vertices.Select(v => new double[] { v.X, v.Z }).ToList();
+                polygonValues=polygon.Vertices.Select(v => new double[] { v.X, v.Z }).ToList();
                 loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XZ_OR_UW;
             }
             else {
-                polygonValues=polgon.Vertices.Select(v => new double[] { v.Y, v.Z }).ToList();
+                polygonValues=polygon.Vertices.Select(v => new double[] { v.Y, v.Z }).ToList();
                 loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_YZ_OR_VW;
             
             }

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.RFEM6
 
             //var i = bhBarLoad.Objects.Elements.ToList().Select(x => x.GetRFEM6ID()).ToList();
 
-            double loadMagintude;
+            double loadMagnitude;
             member_load_load_direction loadDirecteion;
             Vector orientationVector = loadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force : bhBarLoad.Moment;
 
@@ -73,7 +73,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirecteion = member_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE;
                 }
-                loadMagintude = loadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.X : bhBarLoad.Moment.X;
+                loadMagnitude = loadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.X : bhBarLoad.Moment.X;
 
 
             }
@@ -91,7 +91,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirecteion = member_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE;
                 }
-                loadMagintude = loadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.Y : bhBarLoad.Moment.Y;
+                loadMagnitude = loadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.Y : bhBarLoad.Moment.Y;
 
             }
             else
@@ -108,7 +108,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirecteion = member_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE;
                 }
-                loadMagintude = loadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.Z : bhBarLoad.Moment.Z;
+                loadMagnitude = loadType == member_load_load_type.LOAD_TYPE_FORCE ? bhBarLoad.Force.Z : bhBarLoad.Moment.Z;
             }
 
             member_load rfLoadCase = new rfModel.member_load()
@@ -122,7 +122,7 @@ namespace BH.Adapter.RFEM6
                 load_typeSpecified = true,
                 load_direction = loadDirecteion,
                 load_directionSpecified = true,
-                magnitude = loadMagintude,
+                magnitude = loadMagnitude,
                 magnitudeSpecified = true,
                 load_is_over_total_length = true,
                 load_is_over_total_lengthSpecified = true,
@@ -175,7 +175,7 @@ namespace BH.Adapter.RFEM6
         {
 
 
-            double loadMagintude;
+            double loadMagnitude;
             surface_load_load_direction loadDirection;
             Vector orientationVector = bhAreaLoad.Pressure;
 
@@ -200,7 +200,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirection = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_X_OR_USER_DEFINED_U_TRUE;
                 }
-                loadMagintude = orientationVector.X;
+                loadMagnitude = orientationVector.X;
 
             }
             else if (orientationVector.Y != 0)
@@ -217,7 +217,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirection = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_OR_USER_DEFINED_V_TRUE;
                 }
-                loadMagintude = orientationVector.Y;
+                loadMagnitude = orientationVector.Y;
 
             }
             else
@@ -234,7 +234,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirection = surface_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_OR_USER_DEFINED_W_TRUE;
                 }
-                loadMagintude = orientationVector.Z;
+                loadMagnitude = orientationVector.Z;
             }
 
 
@@ -247,9 +247,9 @@ namespace BH.Adapter.RFEM6
                 load_caseSpecified = true,
                 load_distribution = surface_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
                 load_distributionSpecified = true,
-                magnitude_force_u = loadMagintude,
+                magnitude_force_u = loadMagnitude,
                 magnitude_force_uSpecified = true,
-                uniform_magnitude = loadMagintude,
+                uniform_magnitude = loadMagnitude,
                 uniform_magnitudeSpecified = true,
                 is_generated = false,
                 is_generatedSpecified = true,

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -275,7 +275,7 @@ namespace BH.Adapter.RFEM6
             }
 
             Polygon polygon = (Polygon)bhAreaLoad.CustomData.Values.First(p => p is Polygon);
-            List<double[]> polygonValues = new List<double[]>();
+            List<double[]> polygonValues;
             var fitPlane=polgon.IFitPlane();
             if (fitPlane.Normal.CrossProduct(Plane.XY.Normal).Length() < 0.01)
             {

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -266,6 +266,7 @@ namespace BH.Adapter.RFEM6
 
         public static rfModel.free_polygon_load ToRFEM6_Polygon(this AreaUniformlyDistributedLoad bhAreaLoad, int loadCaseSpecificLoadId)
         {
+            free_polygon_load_load_projection loadProjection;
 
             if (bhAreaLoad.Pressure.IsParallel(BH.oM.Geometry.Vector.XAxis)==0 
                 && bhAreaLoad.Pressure.IsParallel(BH.oM.Geometry.Vector.YAxis) == 0
@@ -276,18 +277,21 @@ namespace BH.Adapter.RFEM6
 
             Polygon polygon = (Polygon)bhAreaLoad.CustomData.Values.First(p => p is Polygon);
             List<double[]> polygonValues;
-            var fitPlane=polgon.IFitPlane();
+            var fitPlane=polygon.IFitPlane();
             if (fitPlane.Normal.CrossProduct(Plane.XY.Normal).Length() < 0.01)
             {
-                polygonValues=polgon.Vertices.Select(v => new double[] { v.X, v.Y }).ToList();
+                polygonValues= polygon.Vertices.Select(v => new double[] { v.X, v.Y }).ToList();
+                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XY_OR_UV;
             }
             else if (fitPlane.Normal.CrossProduct(Plane.XZ.Normal).Length() < 0.01)
             {
-                polygonValues=polgon.Vertices.Select(v => new double[] { v.X, v.Z }).ToList();
+                polygonValues= polygon.Vertices.Select(v => new double[] { v.X, v.Z }).ToList();
+                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_XZ_OR_UW;
             }
             else {
-                polygonValues=polgon.Vertices.Select(v => new double[] { v.Y, v.Z }).ToList();
-            
+                polygonValues= polygon.Vertices.Select(v => new double[] { v.Y, v.Z }).ToList();
+                loadProjection = free_polygon_load_load_projection.LOAD_PROJECTION_YZ_OR_VW;
+
             }
 
             free_polygon_load_load_location k = new free_polygon_load_load_location() { first_coordinate = 10, second_coordinate = 100 };

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -274,7 +274,7 @@ namespace BH.Adapter.RFEM6
             {
                 BH.Engine.Base.Compute.RecordWarning($"Please make sure that the direction of {bhAreaLoad} is axis-aligned.");
             }
-
+            
             Polygon polygon = (Polygon)bhAreaLoad.CustomData.Values.First(p => p is Polygon);
             List<double[]> polygonValues;
             var fitPlane=polygon.IFitPlane();
@@ -314,7 +314,7 @@ namespace BH.Adapter.RFEM6
 
             ).ToArray();
 
-            double loadMagintude;
+            double loadMagnitude;
             free_polygon_load_load_direction loadDirection;
             Vector orientationVector = bhAreaLoad.Pressure;
 
@@ -341,7 +341,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirection = free_polygon_load_load_direction.LOAD_DIRECTION_GLOBAL_X_TRUE;
                 }
-                loadMagintude = orientationVector.X;
+                loadMagnitude = orientationVector.X;
 
             }
             else if (orientationVector.Y != 0)
@@ -359,7 +359,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirection = free_polygon_load_load_direction.LOAD_DIRECTION_GLOBAL_Y_TRUE;
                 }
-                loadMagintude = orientationVector.Y;
+                loadMagnitude = orientationVector.Y;
 
             }
             else
@@ -377,7 +377,7 @@ namespace BH.Adapter.RFEM6
                 {
                     loadDirection = free_polygon_load_load_direction.LOAD_DIRECTION_GLOBAL_Z_TRUE;
                 }
-                loadMagintude = orientationVector.Z;
+                loadMagnitude = orientationVector.Z;
             }
 
 
@@ -391,9 +391,9 @@ namespace BH.Adapter.RFEM6
                 load_caseSpecified = true,
                 load_distribution = free_polygon_load_load_distribution.LOAD_DISTRIBUTION_UNIFORM,
                 load_distributionSpecified = true,
-                magnitude_linear_1 = loadMagintude,
+                magnitude_linear_1 = loadMagnitude,
                 magnitude_linear_1Specified = true,
-                magnitude_uniform = loadMagintude,
+                magnitude_uniform = loadMagnitude,
                 magnitude_uniformSpecified = true,
                 is_generated = false,
                 is_generatedSpecified = true,

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Load.cs
@@ -324,6 +324,8 @@ namespace BH.Adapter.RFEM6
                 if (bhAreaLoad.Axis.Equals(LoadAxis.Local))
                 {
                     loadDirection = free_polygon_load_load_direction.LOAD_DIRECTION_LOCAL_X;
+                    if (bhAreaLoad.Projected) BH.Engine.Base.Compute.RecordWarning($"The 'Projected' option for {bhAreaLoad} is not supported when the Axis is set to Local and will therefore be ignored.");
+
                 }
                 else if (bhAreaLoad.Projected)
                 {
@@ -341,6 +343,7 @@ namespace BH.Adapter.RFEM6
                 if (bhAreaLoad.Axis.Equals(LoadAxis.Local))
                 {
                     loadDirection = free_polygon_load_load_direction.LOAD_DIRECTION_LOCAL_Y;
+                    if (bhAreaLoad.Projected) BH.Engine.Base.Compute.RecordWarning($"The 'Projected' option for {bhAreaLoad} is not supported when the Axis is set to Local and will therefore be ignored.");
                 }
                 else if (bhAreaLoad.Projected)
                 {
@@ -358,6 +361,7 @@ namespace BH.Adapter.RFEM6
                 if (bhAreaLoad.Axis.Equals(LoadAxis.Local))
                 {
                     loadDirection = free_polygon_load_load_direction.LOAD_DIRECTION_LOCAL_Z;
+                    if (bhAreaLoad.Projected) BH.Engine.Base.Compute.RecordWarning($"The 'Projected' option for {bhAreaLoad} is not supported when the Axis is set to Local and will therefore be ignored.");
                 }
                 else if (bhAreaLoad.Projected)
                 {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #127 

<!-- Add short description of what has been fixed -->
This PR is aming to add the feature for Pushing/Pulling Free Polygonal Loads to/from RFEM6. 

### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File](https://burohappold.sharepoint.com/:u:/s/BHoM/EaxpAEVQ6A9Iu9ISIHbEEdwBds6_OqpgU3ol3d3J1aufvQ?e=IVj1ua)

For the testing please do the following: 
1. Push Panel Structure/Nodes
2. Push AreaUniformlyDistributedLoad
3. Pull AreaUniformlyDistributedLoad
4. Check soundness of RFEM6 Model
5. Check if Pushed and Pulled Model do match. 
6. Vary AreaUniformlyDistributedLoad preassure direction (Axis Parallel X, Y or Z) and Vary Axis (Local, Glabal) and Projected (True/False)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added Pull Method for AreaUniformlyDistributedLoad with added Polygon Parameter
- Added Push Method for AreaUniformlyDistributedLoad with added Polygon Parameter

