### PR TITLE
Rfem6 toolkit #140 pushing nodes with constraints triggers issue

### DIFF
--- a/RFEM6_Adapter/Comparers/RFEMNodalComparer.cs
+++ b/RFEM6_Adapter/Comparers/RFEMNodalComparer.cs
@@ -34,14 +34,15 @@ namespace BH.Adapter.RFEM6
 {
     public class RFEMNodalComparer : IEqualityComparer<Node>
     {
-        /***************************************************/
-        /**** Constructors                              ****/
-        /***************************************************/
+		/***************************************************/
+		/**** Constructors                              ****/
+		/***************************************************/
+		private static readonly NodeDistanceComparer _nodeComp = new NodeDistanceComparer(3);
 
-        public RFEMNodalComparer()
+		public RFEMNodalComparer()
         {
 
-        }
+		}
 
 
         /***************************************************/
@@ -56,11 +57,9 @@ namespace BH.Adapter.RFEM6
             Constraint6DOF c1 = node1.Support as Constraint6DOF;
             Constraint6DOF c2 = node2.Support as Constraint6DOF;
 
-            Constraint6DOFComparer constraint6DOFComparer = new Constraint6DOFComparer();
             
-            var nodecomp = new NodeDistanceComparer(3);
             
-            if (!nodecomp.Equals(node1, node2)) return false;
+            if (!_nodeComp.Equals(node1, node2)) return false;
 
             //Nodes are equal
             if ((c1 is null) && (c2 is null)) return true;
@@ -86,7 +85,7 @@ namespace BH.Adapter.RFEM6
                 && c1.RotationZ == c2.RotationZ;
 
 
-            return supportsAreEqual && nodecomp.Equals(node1, node2);
+            return supportsAreEqual && _nodeComp.Equals(node1, node2);
         }
 
         /***************************************************/

--- a/RFEM6_Adapter/Comparers/RFEMNodalComparer.cs
+++ b/RFEM6_Adapter/Comparers/RFEMNodalComparer.cs
@@ -57,7 +57,20 @@ namespace BH.Adapter.RFEM6
             Constraint6DOF c2 = node2.Support as Constraint6DOF;
 
             Constraint6DOFComparer constraint6DOFComparer = new Constraint6DOFComparer();
+            
+            var nodecomp = new NodeDistanceComparer(3);
+            
+            if (!nodecomp.Equals(node1, node2)) return false;
 
+            //Nodes are equal
+            if ((c1 is null) && (c2 is null)) return true;
+            
+            //Atelase one support is not null
+            if ((c1 is null) && !(c2 is null)) return false;
+            if (!(c1 is null) && (c2 is null)) return false;
+
+
+            //Both support are not null
             bool supportsAreEqual =
                 c1.TranslationalStiffnessX == c2.TranslationalStiffnessX
                 && c1.TranslationalStiffnessY == c2.TranslationalStiffnessY
@@ -72,7 +85,6 @@ namespace BH.Adapter.RFEM6
                 && c1.RotationY == c2.RotationY
                 && c1.RotationZ == c2.RotationZ;
 
-            var nodecomp = new NodeDistanceComparer(3);
 
             return supportsAreEqual && nodecomp.Equals(node1, node2);
         }


### PR DESCRIPTION
### Issues addressed by this PR
Closes #140  <!-- fill in issue number -->

Fix `NullReferenceException` in `RFEMNodalComparer.Equals()` when pushing nodes without constraints to RFEM.

### Test files
<!-- TODO: link to test file -->


### Changelog
- Fixed `RFEMNodalComparer` to handle nodes with `null` supports without throwing
- Refactored comparer: made `NodeDistanceComparer` a `static readonly` field, simplified null checks, removed redundant `Equals()` call

### Additional comments
The root cause was that `RFEMNodalComparer.Equals()` did not account for `Node.Support` being `null`. While the null checks existed, a case-sensitivity typo on the field name (`_nodecomp` vs `_nodeComp`) prevented compilation, and the duplicate `nodecomp.Equals()` call at the end of the method was unnecessary. Took the opportunity to clean up the overall implementation.