### PR TITLE
Fixing call of loadcase in conversion of loadcombinations

### DIFF
--- a/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/LoadCombination.cs
+++ b/RFEM6_Adapter/Convert/FromRFEM6/BHoMDataStructure/Loading/LoadCombination.cs
@@ -44,7 +44,8 @@ namespace BH.Adapter.RFEM6
 			var factors = rfLoadCombination.individual_factors_of_selected_objects_table;
 
 			double[] factorsArray = rfLoadCombination.items.Select(i => i.row.factor).ToArray();
-			Loadcase[] loadCaseArray = rfLoadCombination.items.Select(i => i.no).Select(s => loadCaseDict[s]).ToArray();
+
+			Loadcase[] loadCaseArray = rfLoadCombination.items.Select(i => i.row.load_case).Select(s => loadCaseDict[s]).ToArray();
 
 			List<Tuple<double, ICase>> tupelList = factorsArray.Zip(loadCaseArray, (f, l) => Tuple.Create(f, l as ICase)).ToList();
 


### PR DESCRIPTION
### Issues addressed by this PR
Closes #146 

Fixed a bug in the pull (read) conversion of `LoadCombination` from RFEM6, where the load case ID was being read from `i.no` (the item row index) instead of `i.row.load_case` (the actual load case reference). This caused incorrect load case lookup when converting load combinations.

## Test files
Please make sure that the quantity of loadcombination pulledn and the one in the test file does match. Idally also do a few visual checks. 

[Test Files](https://burohappold.sharepoint.com/:f:/s/BHoM/IgD8M74ic4RiQ4ESxA5U0iLcAWGAmWQlVn_LFgerQr7W6cQ?e=mGg8enl)


### Changelog
- Fixed bug in `LoadCombination` pull conversion: load case ID now correctly read from `i.row.load_case` instead of `i.no`.
