### PR TITLE
Enabeling Pull of Nodal Support Reaction For Load Combinations

### DIFF
--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/BarResults.cs
@@ -80,24 +80,18 @@ namespace BH.Adapter.RFEM6
             {
                 int cId = 0;
 
-                if (c is Loadcase)
+                if (c is Loadcase lc)
                 {
-                    cId = (c as Loadcase).Number;
-
+                    cId = lc.Number;
                 }
-                else if (c is LoadCombination)
+                else if (c is LoadCombination lcom)
                 {
-
-                    cId = (c as LoadCombination).Number;
-
+                    cId = lcom.Number;
                 }
                 else
                 {
-
                     cId = Int32.Parse(c.ToString());
                 }
-
-
 
                 //Loading resulst from RFEM
                 INotifyPropertyChanged[] barResults = new INotifyPropertyChanged[1];
@@ -139,13 +133,11 @@ namespace BH.Adapter.RFEM6
                     double memberLength = 0;
                     try
                     {
-
                         if (barDictionary.Keys.Contains(member.Key))
                         {
                             memberLength = barDictionary[member.Key].Length();
                             continue;
                         }
-
                         String lengthAsString = member.ToList()[0].PropertyValue("row.specification").ToString().Split(new[] { "L : ", " m" }, StringSplitOptions.None)[1];
                         memberLength = double.Parse(lengthAsString, CultureInfo.InvariantCulture);// Member Length in SI unit m;
                     }
@@ -155,17 +147,13 @@ namespace BH.Adapter.RFEM6
                         memberLength = barDictionary[member.Key].Length();
                     }
 
-
-
                     var memberSegmentValues = member.ToList();
 
                     //If we are looking for exterme Values
                     if (request.DivisionType == DivisionType.ExtremeValues)
                     {
-
                         memberSegmentValues = member.SkipWhile(m => !m.PropertyValue("description").ToString().Contains("Extremes")).ToList();
                         memberSegmentValues = memberSegmentValues.TakeWhile(m => !m.PropertyValue("description").ToString().Contains("Total")).ToList();
-
                     }
 
                     else

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
@@ -22,22 +22,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 using BH.oM.Adapter;
-using BH.oM.Structure.Elements;
-using BH.oM.Structure.Constraints;
 
 using rfModel = Dlubal.WS.Rfem6.Model;
-using BH.oM.Adapters.RFEM6;
 using BH.oM.Structure.Loads;
 using Dlubal.WS.Rfem6.Model;
-using System.Xml.Linq;
-using BH.Engine.Base;
 using BH.oM.Analytical.Results;
 using BH.oM.Structure.Requests;
 using BH.oM.Structure.Results;
-using System.Configuration;
 
 namespace BH.Adapter.RFEM6
 {
@@ -49,28 +42,30 @@ namespace BH.Adapter.RFEM6
 	public partial class RFEM6Adapter
 #endif
 	{
-
+		/// <summary>
+		/// Reads results from RFEM6 based on the provided <see cref="NodeResultRequest"/>.
+		/// Resolves node IDs and load cases from the request, then dispatches to the appropriate extraction method.
+		/// </summary>
+		/// <param name="request">The request defining which nodes, load cases, and result type to extract.</param>
+		/// <param name="actionConfig">Adapter action configuration.</param>
+		/// <returns>A collection of <see cref="IResult"/> objects, or an empty list if the result type is not supported.</returns>
 		public IEnumerable<IResult> ReadResults(NodeResultRequest request, ActionConfig actionConfig)
 		{
 
 			List<int> nodeIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
-			List<int> caseIds = new List<int>();
 			Dictionary<int, case_object_types> caseIDToTypeMap = new Dictionary<int, case_object_types>();
-			foreach (var c in request.Cases)
+			foreach (object c in request.Cases)
 			{
 
-				if (c is Loadcase)
+				if (c is Loadcase loadcase)
 				{
 
-					caseIds.Add(Int32.Parse((c as Loadcase).Number.ToString()));
-					caseIDToTypeMap.Add(Int32.Parse((c as Loadcase).Number.ToString()), case_object_types.E_OBJECT_TYPE_LOAD_CASE);
-
+					caseIDToTypeMap.Add(Int32.Parse(loadcase.Number.ToString()), case_object_types.E_OBJECT_TYPE_LOAD_CASE);
 				}
-				else if (c is LoadCombination)
+				else if (c is LoadCombination loadCombination)
 				{
 
-					caseIds.Add(Int32.Parse((c as LoadCombination).Number.ToString()));
-					caseIDToTypeMap.Add((c as LoadCombination).Number, case_object_types.E_OBJECT_TYPE_LOAD_COMBINATION);
+					caseIDToTypeMap.Add(Int32.Parse(loadCombination.Number.ToString()), case_object_types.E_OBJECT_TYPE_LOAD_COMBINATION);
 
 				}
 
@@ -81,7 +76,6 @@ namespace BH.Adapter.RFEM6
 
 				case NodeResultType.NodeReaction:
 
-					//m_Model.calculate_all(true);
 					var result = ExtractNodeReaction(nodeIds, caseIDToTypeMap);
 					return result;
 
@@ -93,21 +87,33 @@ namespace BH.Adapter.RFEM6
 
 			}
 
-			return null;
+			return new List<IResult>();
 		}
-
+		/// <summary>
+		/// Extracts nodal support reaction forces and moments from RFEM6 for the given nodes and load cases.
+		/// Triggers a model calculation, then retrieves support forces for all nodal supports.
+		/// Only nodes linked to a nodal support will return results; others are skipped with a warning.
+		/// </summary>
+		/// <param name="nodeIds">List of node IDs to extract reactions for. If empty, all nodes are used.</param>
+		/// <param name="loadCaseIds">Map of load case/combination IDs to their RFEM6 object type.</param>
+		/// <returns>A list of <see cref="NodeReaction"/> results.</returns>
 		private IEnumerable<IResult> ExtractNodeReaction(List<int> nodeIds, Dictionary<int, case_object_types> loadCaseIds)
 		{
 
 			List<IResult> resultList = new List<IResult>();
-			object_location[] filter = null;
 
-			rfModel.object_with_children[] nodalSupportObjWitheChildern = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODAL_SUPPORT);
-			nodalSupportObjWitheChildern = nodalSupportObjWitheChildern.ToList().Where(n => n.no != 0).ToArray();
-			IEnumerable<rfModel.nodal_support> nodalSupport = nodalSupportObjWitheChildern.Length >= 1 ? nodalSupportObjWitheChildern.ToList().Select(n => m_Model.get_nodal_support(n.no)) : new List<rfModel.nodal_support>();
+
+			//Get all nodal supports and filter out the ones with no number (no = 0)
+			rfModel.object_with_children[] nodalSupportObjWithChildern = m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODAL_SUPPORT);
+			nodalSupportObjWithChildern = nodalSupportObjWithChildern.Where(n => n.no != 0).ToArray();
+			IEnumerable<rfModel.nodal_support> nodalSupport = nodalSupportObjWithChildern.Length >= 1 ? nodalSupportObjWithChildern.Select(n => m_Model.get_nodal_support(n.no)) : new List<rfModel.nodal_support>();
 
 			List<int> nodalSupportNo = nodalSupport.ToList().Select(n => n.no).ToList();
 
+			nodalSupport.First().nodes.ToList();
+
+			//Filter to get only nodal supports that are linked to nodes. This is because only those will have support forces and moments results.
+			object_location[] filter = null;
 			if (nodalSupportNo.Count != 0)
 			{
 
@@ -119,9 +125,8 @@ namespace BH.Adapter.RFEM6
 				return resultList;
 			}
 
-
+			//Calculate the model to make sure that results are up to date. This is important especially if the user has made changes to the model and has not calculated it yet.
 			m_Model.calculate_all(true);
-
 
 
 			foreach (var lc in loadCaseIds)
@@ -137,7 +142,8 @@ namespace BH.Adapter.RFEM6
 				//Gather all ids of Nodes that are linked to a Nodal support
 				HashSet<int> idsOfAllNodesLikedToNodalSupport = res_all.Select(z => z.row.node_no).ToHashSet();
 
-				nodeIds = nodeIds.Count == 0 ? m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODE).ToList().Select(n=>n.no).ToList() : nodeIds;
+				//If no node ids have been provided in the request, we will extract results for all nodes that are linked to a nodal support. Otherwise, we will only extract results for the node ids provided in the request.
+				nodeIds = nodeIds.Count == 0 ? nodalSupport.SelectMany(s => s.nodes).Distinct().ToList() : nodeIds;
 
 				for (int i = 0; i < nodeIds.Count; i++)
 				{

--- a/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
+++ b/RFEM6_Adapter/CRUD/Read/BHoMDataStructure/Result/NodeReaction.cs
@@ -53,10 +53,28 @@ namespace BH.Adapter.RFEM6
 		public IEnumerable<IResult> ReadResults(NodeResultRequest request, ActionConfig actionConfig)
 		{
 
-
-
 			List<int> nodeIds = request.ObjectIds.Select(s => Int32.Parse(s.ToString())).ToList();
-			List<int> loadCaseIds = request.Cases.Select(s => Int32.Parse(s.ToString())).ToList();
+			List<int> caseIds = new List<int>();
+			Dictionary<int, case_object_types> caseIDToTypeMap = new Dictionary<int, case_object_types>();
+			foreach (var c in request.Cases)
+			{
+
+				if (c is Loadcase)
+				{
+
+					caseIds.Add(Int32.Parse((c as Loadcase).Number.ToString()));
+					caseIDToTypeMap.Add(Int32.Parse((c as Loadcase).Number.ToString()), case_object_types.E_OBJECT_TYPE_LOAD_CASE);
+
+				}
+				else if (c is LoadCombination)
+				{
+
+					caseIds.Add(Int32.Parse((c as LoadCombination).Number.ToString()));
+					caseIDToTypeMap.Add((c as LoadCombination).Number, case_object_types.E_OBJECT_TYPE_LOAD_COMBINATION);
+
+				}
+
+			}
 
 			switch (request.ResultType)
 			{
@@ -64,7 +82,7 @@ namespace BH.Adapter.RFEM6
 				case NodeResultType.NodeReaction:
 
 					//m_Model.calculate_all(true);
-					var result = ExtractNodeReaction(nodeIds, loadCaseIds);
+					var result = ExtractNodeReaction(nodeIds, caseIDToTypeMap);
 					return result;
 
 				default:
@@ -78,7 +96,7 @@ namespace BH.Adapter.RFEM6
 			return null;
 		}
 
-		private IEnumerable<IResult> ExtractNodeReaction(List<int> nodeIds, List<int> loadCaseIds)
+		private IEnumerable<IResult> ExtractNodeReaction(List<int> nodeIds, Dictionary<int, case_object_types> loadCaseIds)
 		{
 
 			List<IResult> resultList = new List<IResult>();
@@ -104,18 +122,22 @@ namespace BH.Adapter.RFEM6
 
 			m_Model.calculate_all(true);
 
-			foreach (int lc in loadCaseIds)
+
+
+			foreach (var lc in loadCaseIds)
 			{
 
 				nodes_support_forces_row[] res_all = m_Model.get_results_for_nodes_support_forces(
-					case_object_types.E_OBJECT_TYPE_LOAD_CASE,
-					lc,
+					lc.Value,
+					lc.Key,
 					filter
 					);
 
 
 				//Gather all ids of Nodes that are linked to a Nodal support
 				HashSet<int> idsOfAllNodesLikedToNodalSupport = res_all.Select(z => z.row.node_no).ToHashSet();
+
+				nodeIds = nodeIds.Count == 0 ? m_Model.get_all_object_numbers_by_type(rfModel.object_types.E_OBJECT_TYPE_NODE).ToList().Select(n=>n.no).ToList() : nodeIds;
 
 				for (int i = 0; i < nodeIds.Count; i++)
 				{
@@ -125,7 +147,7 @@ namespace BH.Adapter.RFEM6
 						BH.Engine.Base.Compute.RecordWarning(String.Format("There is no node id {0} linked to an Nodal Support", nodeIds[i]));
 						continue;
 					}
-					
+
 
 					var r = res_all.First(k => k.row.node_no.Equals(nodeIds[i]));
 
@@ -136,7 +158,7 @@ namespace BH.Adapter.RFEM6
 					double myValue = r.row.support_moment_m_y;
 					double mzValue = r.row.support_moment_m_z;
 
-					NodeReaction nodeReaction = new NodeReaction(r.row.node_no, lc, 0, 0, oM.Geometry.Basis.XY, fxValue, fyValue, fzValue, mxValue, myValue, mzValue);
+					NodeReaction nodeReaction = new NodeReaction(r.row.node_no, lc.Key, 0, 0, oM.Geometry.Basis.XY, fxValue, fyValue, fzValue, mxValue, myValue, mzValue);
 					resultList.Add(nodeReaction);
 				}
 

--- a/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Loadcase.cs
+++ b/RFEM6_Adapter/Convert/ToRFEM6/BHoMDataStructure/Loading/Loadcase.cs
@@ -42,8 +42,6 @@ namespace BH.Adapter.RFEM6
 
         public static rfModel.load_case ToRFEM6(this Loadcase bhLoadcase, int analysisNo)
         {
-
-
             load_case rfLoadCase = new rfModel.load_case()
             {
                 no = bhLoadcase.Number,
@@ -58,10 +56,7 @@ namespace BH.Adapter.RFEM6
                 stability_analysis_settings = analysisNo,
                 stability_analysis_settingsSpecified = true,
             };
-
-
             return rfLoadCase;
-
         }
 
         private static String ToRFEM(this LoadNature loadNature)
@@ -105,9 +100,6 @@ namespace BH.Adapter.RFEM6
                     BH.Engine.Base.Compute.RecordWarning($"Load cases of Nature Type {loadNature} will be set as Dead Load!");
                     return "ACTION_CATEGORY_PERMANENT_G";
             }
-
-
-            //return "";
         }
 
     }


### PR DESCRIPTION
### Issues addressed by this PR

Closes #95

Enables pulling of nodal support reaction forces and moments for both Load Cases and Load Combinations. Previously only Load Cases were supported. The `ReadResults` method now correctly maps `LoadCombination` objects to the appropriate RFEM6 case type, allowing reactions to be extracted for both case types in a single pull.

### Test files

[Test Files](https://burohappold.sharepoint.com/:f:/s/BHoM/IgDdXNN8g3yJTbHcVQrBsCT7AWR_oJJw0IWCEJnUSWbbddU?e=EdmPmG)

**Test procedure:**
1. Read Nodes and Load Combinations by toggling the adapter to on
2. Pull Nodal Reactions
3. Inspect Node Reactions by spot checks

### Changelog

- `NodeReaction.cs` — Extended `ReadResults` to support `LoadCombination` alongside `Loadcase` when extracting nodal support reactions
- `NodeReaction.cs` — Refactored `ExtractNodeReaction` for clarity and correctness; removed redundant LINQ allocations and fixed inconsistent null return
- `BarResults.cs` — Minor cleanup in line with refactoring

### Additional comments

Only nodes linked to a defined nodal support will return reactions. Nodes without a nodal support are skipped with a recorded warning.
