### PR TITLE
Rfem6 toolkit #157 add warning to adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,53 @@
-# template-repository
-This repository can be used to create brand new BHoM Toolkits :rocket:
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0) [![Build status](https://ci.appveyor.com/api/projects/status/cko96y5mg2wm4myr/branch/master?svg=true)](https://ci.appveyor.com/api/projects/status/cko96y5mg2wm4myr/branch/master?svg=true) [![Build Status](https://dev.azure.com/BHoMBot/BHoM/_apis/build/status/Lusas_Toolkit/Lusas_Toolkit.CheckCore?branchName=master)](https://dev.azure.com/BHoMBot/BHoM/_build/latest?definitionId=108&branchName=master)
 
-- Just click on the green button above "Use this template" :point_up_2: . Call the new repo with the name of your software followed by `_Toolkit`, e.g. "MySoftware_Toolkit".
-- In your new repository, double click the `RenameToolkitFiles.bat` file. When asked, insert the name of your software, e.g. "MySoftware". All the files and folder will be renamed accordingly.
-- Start developing! :rocket:
+# RFEM6_Toolkit
 
-## Configure development environment
-Learn how to [rapidly Getting Started for Developers](https://bhom.xyz/documentation/Guides-and-Tutorials/Coding-with-BHoM/). 
+This toolkit allows interoperability between the BHoM and RFEM6. It enables creation, manipulation and reading of structural finite element analysis models and analysis results. Please see the [BHoM RFEM6 Object Relations](https://github.com/BHoM/RFEM6_Toolkit/wiki/Feature-Overview) for a comprehensive list of supported BHoM objects.
 
-If you want, you can also add [Engine methods templates](https://github.com/BHoM/documentation/tree/master/templates/Engine%20method%20templates). 
+https://www.dlubal.com/en/products/rfem-fea-software/rfem/what-is-rfem?srsltid=AfmBOoq3j1_L003WaFTw4thLi0UWIl8W-Yjd-JDNCkF6-5xb45P4t66Z
+
+### API
+The RFEM6_Toolkit uses the RFEMWebServiceLibrary to connect to active sessions of RFEM. The webservice is no longer maintained or actively developed by Dlubal. Refer to:
+https://github.com/dlubal-software/Dlubal_CSharp_Client#important-notice-webservice-maintenance-and-dlubal-api-transition
+
+### Tested versions of RFEM6 for 9.2 (using `RFEM6AdapterV12_11`)
+
+6.14.0008  
+6.14.0002
+
+To use 6.12.11 or earlier use the `RFEM6AdapterV8_2`. 
+
+For RFEM5 refer to: https://github.com/BHoM/RFEM5_Toolkit
+
+### Common Errors
+- Not all licences support legacy API usage - you will recieve errors relating to a demo licence which limits the number of elements to 12.
+- The Dlubal Grasshopper Plugin should be uninstalled as it may cause conflicts with the RFEM6_Toolkit.
+
+### Documentation
+For more information about functionality see the [RFEM6_Toolkit Wiki](https://github.com/BHoM/RFEM6_Toolkit/wiki)
+
+---
+This toolkit is part of the Buildings and Habitats object Model. Find out more on our [wiki](https://github.com/BHoM/documentation/wiki) or at [https://bhom.xyz](https://bhom.xyz/)
+
+## Quick Start 🚀 
+
+Grab the [latest installer](https://bhom.xyz/) and a selection of [sample scripts](https://github.com/BHoM/samples).
 
 
-## Implement the Toolkits
-See the instructions in [the wiki page on the BHoM_Toolkit](https://github.com/BHoM/documentation/wiki/The-BHoM-Toolkit).
+## Getting Started for Developers 🤖 
+
+If you want to build the BHoM and the Toolkits from source, it's hopefully easy! 😄 
+Do take a look at our specific wiki pages here: [Getting Started for Developers](https://bhom.xyz/documentation/Guides-and-Tutorials/Coding-with-BHoM/)
+
+
+## Want to Contribute? ##
+
+BHoM is an open-source project and would be nothing without its community. Take a look at our contributing guidelines and tips [here](https://github.com/BHoM/BHoM/blob/main/CONTRIBUTING.md).
+
+
+## Licence ##
+
+BHoM is free software licenced under GNU Lesser General Public Licence - [https://www.gnu.org/licenses/lgpl-3.0.html](https://www.gnu.org/licenses/lgpl-3.0.html)  
+Each contributor holds copyright over their respective contributions.
+The project versioning (Git) records all such contribution source information.
+See [LICENSE](https://github.com/BHoM/BHoM/blob/main/LICENSE) and [COPYRIGHT_HEADER](https://github.com/BHoM/BHoM/blob/main/COPYRIGHT_HEADER.txt).

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 # RFEM6_Toolkit
 
-This toolkit allows interoperability between the BHoM and RFEM6. It enables creation, manipulation and reading of structural finite element analysis models and analysis results. Please see the [BHoM RFEM6 Object Relations](https://github.com/BHoM/RFEM6_Toolkit/wiki/Feature-Overview) for a comprehensive list of supported BHoM objects.
-
-https://www.dlubal.com/en/products/rfem-fea-software/rfem/what-is-rfem?srsltid=AfmBOoq3j1_L003WaFTw4thLi0UWIl8W-Yjd-JDNCkF6-5xb45P4t66Z
+This toolkit allows interoperability between the BHoM and (RFEM6)[https://www.dlubal.com/en/products/rfem-fea-software/rfem/what-is-rfem?srsltid=AfmBOoq3j1_L003WaFTw4thLi0UWIl8W-Yjd-JDNCkF6-5xb45P4t66Z]. It enables creation, manipulation and reading of structural finite element analysis models and analysis results. Please see the [BHoM RFEM6 Object Relations](https://github.com/BHoM/RFEM6_Toolkit/wiki/Feature-Overview) for a comprehensive list of supported BHoM objects.
 
 ### API
 The RFEM6_Toolkit uses the RFEMWebServiceLibrary to connect to active sessions of RFEM. The webservice is no longer maintained or actively developed by Dlubal. Refer to:

--- a/RFEM6_Adapter/RFEM6Adapter.cs
+++ b/RFEM6_Adapter/RFEM6Adapter.cs
@@ -113,6 +113,13 @@ namespace BH.Adapter.RFEM6
         public RFEM6Adapter(string filePath = "", bool active = false)
 #endif
         {
+#if RFEM6_8_2
+            Engine.Base.Compute.RecordWarning("This adapter should be used for RFEM6 versions 6.12.11 or older. \n" +
+    "Please refer to the README for further details: https://github.com/BHoM/RFEM6_Toolkit");
+#else
+            Engine.Base.Compute.RecordWarning("This toolkit has been tested for RFEM6 versions 6.14.0002 and 6.14.0008. \n" +
+                "Please refer to the README for further detail: https://github.com/BHoM/RFEM6_Toolkit.");
+#endif
 
             if (active)
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #157 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Place `RFEM6Adapter`, RFEM6AdapterV12_11` or `RFEM6AdapterV8_2` to see the relevant warning messages.
README can be previewed here: 
https://github.com/BHoM/RFEM6_Toolkit/blob/RFEM6_Toolkit-%23157-AddWarningToAdapter/README.md

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Add warning messages to the `Adapter` components that direct users to the README as a result of 9.2 deployment testing;
- Update README to specify which versions have been tested and work;
- Update README to clarify the changes in API approach by Dlubal;
- Update README to highlight common errors relating to demo licences and API usage.

### Additional comments
<!-- As required -->
